### PR TITLE
bugfix: Trailing zeros in num2hex()

### DIFF
--- a/R/sha1.R
+++ b/R/sha1.R
@@ -170,7 +170,7 @@ num2hex <- function(x, digits = 14, zapsmall = 7){
   mantissa <- gsub(mantissa, pattern = "p.*$", replacement = "")
   mantissa <- substring(mantissa, 1, digits.hex) # select required precision
   # remove potential trailing zero's
-  mantissa <- gsub(mantissa, pattern = "0$", replacement = "")
+  mantissa <- gsub(mantissa, pattern = "0*$", replacement = "")
   negative <- ifelse(grepl(x.hex[!zero], pattern = "^-"), "-", "")
   output[!x.na][!zero] <- paste0(negative, mantissa, " ", exponent[!zero])
   return(output)

--- a/tests/num2hexTest.R
+++ b/tests/num2hexTest.R
@@ -87,3 +87,17 @@ stopifnot(
     )
 )
 
+# example from FAQ 7.31
+# tests if all trailing zero's are removed
+stopifnot(
+    identical(
+        digest:::num2hex(2, digits = 14),
+        digest:::num2hex(sqrt(2) ^ 2, digits = 14)
+    )
+)
+stopifnot(
+    !identical(
+        digest:::num2hex(2, digits = 15),
+        digest:::num2hex(sqrt(2) ^ 2, digits = 15)
+    )
+)


### PR DESCRIPTION
`num2hex()` removed only the last trailing zero instead of all trailing zeros. `digest:::num2hex(sqrt(2) ^ 2)` returned `"00000000000 1"` instead of `" 1"` which is the output of `digest:::num2hex(2)` As a result `sha1(2) != sha1(sqrt(2) ^ 2)`. This is now fixed.