### PR TITLE
ROBUSTNESS: Now the digest DLL is unloaded when the package is unloaded

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Author: Dirk Eddelbuettel <edd@debian.org> with contributions
  Mario Frasca, Bryan Lewis, Murray Stokely, Hannes Muehleisen,
  Duncan Murdoch, Jim Hester, Wush Wu, Qiang Kou, Thierry Onkelinx, 
  Michel Lang and Viliam Simko.
-Version: 0.6.9.3
-Date: 2016-05-25
+Version: 0.6.9.4
+Date: 2016-07-11
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Title: Create Compact Hash Digests of R Objects
 Description: Implementation of a function 'digest()' for the creation 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,3 @@
+.onUnload <- function (libpath) {
+  library.dynam.unload("digest", libpath)
+}

--- a/tests/load-unload.R
+++ b/tests/load-unload.R
@@ -1,0 +1,25 @@
+## Test that package can be loaded and unloaded cleanly
+
+dlls0 <- getLoadedDLLs()
+stopifnot(!is.element("digest", loadedNamespaces()),
+          !is.element("digest", names(dlls0)))
+
+loadNamespace("digest")
+dlls1 <- getLoadedDLLs()
+stopifnot(length(dlls1) == length(dlls0) + 1,
+          is.element("digest", names(dlls1)))
+
+unloadNamespace("digest")
+dlls2 <- getLoadedDLLs()
+stopifnot(length(dlls2) == length(dlls0),
+          !is.element("digest", names(dlls2)))
+
+library("digest")
+dlls3 <- getLoadedDLLs()
+stopifnot(length(dlls3) == length(dlls0) + 1,
+          is.element("digest", names(dlls3)))
+
+unloadNamespace("digest")
+dlls4 <- getLoadedDLLs()
+stopifnot(length(dlls4) == length(dlls0),
+          !is.element("digest", names(dlls4)))


### PR DESCRIPTION
I know you prefer issue discussions first, but I'd say this one is pretty obvious.  With digest (<= 0.6.9.3) we get:
```r
> library("digest")
> unloadNamespace("digest")
> getLoadedDLLs()
                                                                  Filename Dynamic.Lookup
base                                                                  base          FALSE
methods                         /usr/lib/R/library/methods/libs/methods.so          FALSE
utils                               /usr/lib/R/library/utils/libs/utils.so          FALSE
tools                               /usr/lib/R/library/tools/libs/tools.so          FALSE
internet                                   /usr/lib/R/modules//internet.so           TRUE
grDevices                   /usr/lib/R/library/grDevices/libs/grDevices.so          FALSE
graphics                      /usr/lib/R/library/graphics/libs/graphics.so          FALSE
stats                               /usr/lib/R/library/stats/libs/stats.so          FALSE
digest    /home/hb/R/x86_64-pc-linux-gnu-library/3.3/digest/libs/digest.so           TRUE
```

This PR makes sure the digest DLL/SO is unloaded together with the namespace.

See also https://github.com/HenrikBengtsson/Wishlist-for-R/issues/29