### PR TITLE
sha1() gains an algo argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-01-21  Thierry Onkelinx  <thierry.onkelinx@inbo.be>
+
+	* sha1() gains an `algo` argument
+	* sha1() handles raw class
+
 2018-01-14  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Date, Version): Release 0.6.14

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -30,6 +30,7 @@ S3method(sha1, numeric)
 S3method(sha1, pairlist)
 S3method(sha1, POSIXct)
 S3method(sha1, POSIXlt)
+S3method(sha1, raw)
 
 S3method(makeRaw, default)
 S3method(makeRaw, digest)

--- a/R/sha1.R
+++ b/R/sha1.R
@@ -1,9 +1,9 @@
 # functions written by Thierry Onkelinx
-sha1 <- function(x, digits = 14L, zapsmall = 7L, ...){
+sha1 <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
     UseMethod("sha1")
 }
 
-sha1.default <- function(x, digits = 14L, zapsmall = 7L, ...) {
+sha1.default <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     stop(
         "sha1() has no method for the '",
         paste(class(x), collapse = "', '"),
@@ -12,67 +12,52 @@ sha1.default <- function(x, digits = 14L, zapsmall = 7L, ...) {
     )
 }
 
-sha1.integer <- function(x, digits = 14L, zapsmall = 7L, ...) {
-    attr(x, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+sha1.integer <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
+    attr(x, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    digest(x, algo = "sha1")
+    digest(x, algo = algo)
 }
 
-sha1.character <- function(x, digits = 14L, zapsmall = 7L, ...) {
-    attr(x, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+sha1.character <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
+    attr(x, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    digest(x, algo = "sha1")
+    digest(x, algo = algo)
 }
 
-sha1.factor <- function(x, digits = 14L, zapsmall = 7L, ...) {
-    attr(x, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+sha1.factor <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
+    attr(x, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    digest(x, algo = "sha1")
+    digest(x, algo = algo)
 }
 
-sha1.NULL <- function(x, digits = 14L, zapsmall = 7L, ...) {
+sha1.NULL <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     # attributes cannot be set on a NULL object
-    digest(x, algo = "sha1")
+    digest(x, algo = algo)
 }
 
-sha1.logical <- function(x, digits = 14L, zapsmall = 7L, ...) {
-    attr(x, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+sha1.logical <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
+    attr(x, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    digest(x, algo = "sha1")
+    digest(x, algo = algo)
 }
 
-sha1.numeric <- function(x, digits = 14L, zapsmall = 7L, ...){
+sha1.numeric <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
     y <- num2hex(
         x,
         digits = digits,
         zapsmall = zapsmall
     )
-    attr(y, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    digest(y, algo = "sha1")
+    digest(y, algo = algo)
 }
 
-sha1.matrix <- function(x, digits = 14L, zapsmall = 7L, ...){
+sha1.matrix <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
     # needed to make results comparable between 32-bit and 64-bit
     if (storage.mode(x) == "double") {
         y <- matrix( #return a matrix with the same dimensions as x
@@ -81,69 +66,53 @@ sha1.matrix <- function(x, digits = 14L, zapsmall = 7L, ...){
                 2,
                 num2hex,
                 digits = digits,
-                zapsmall = zapsmall,
-                ... = ...
+                zapsmall = zapsmall
             ),
             ncol = ncol(x)
         )
-        attr(y, "digest::sha1") <- list(
-            class = class(x),
-            digits = as.integer(digits),
-            zapsmall = as.integer(zapsmall),
-            ... = ...
+        attr(y, "digest::sha1") <- attr_sha1(
+            x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
         )
-        digest(y, algo = "sha1")
+        digest(y, algo = algo)
     } else {
-        attr(x, "digest::sha1") <- list(
-            class = class(x),
-            digits = as.integer(digits),
-            zapsmall = as.integer(zapsmall),
-            ... = ...
+        attr(x, "digest::sha1") <- attr_sha1(
+            x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
         )
-        digest(x, algo = "sha1")
+        digest(x, algo = algo)
     }
 }
 
-sha1.complex <- function(x, digits = 14L, zapsmall = 7L, ...) {
+sha1.complex <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     # a vector of complex numbers is converted into 2-column matrix (Re,Im)
     y <- cbind(Re(x), Im(x))
-    attr(y, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    sha1(y, digits = digits, zapsmall = zapsmall, ...)
+    sha1(y, digits = digits, zapsmall = zapsmall, ..., algo = algo)
 }
 
-sha1.Date <- function(x, digits = 14L, zapsmall = 7L, ...) {
+sha1.Date <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     y <- as.numeric(x)
-    attr(y, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    sha1(y, digits = digits, zapsmall = zapsmall, ...)
+    sha1(y, digits = digits, zapsmall = zapsmall, ..., algo = algo)
 }
 
-sha1.array <- function(x, digits = 14L, zapsmall = 7L, ...) {
+sha1.array <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     # Array x encoded as list of two elements:
     # 1. lengths of all dimensions of x
     # 2. all cells of x as a single vector
     y <- list(
         dimension = dim(x),
         value = as.numeric(x))
-    attr(y, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    sha1(y, digits = digits, zapsmall = zapsmall, ...)
+    sha1(y, digits = digits, zapsmall = zapsmall, ..., algo = algo)
 }
 
-sha1.data.frame <- function(x, digits = 14L, zapsmall = 7L, ...){
+sha1.data.frame <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
     if (length(x)) {
         # needed to make results comparable between 32-bit and 64-bit
         y <- vapply(
@@ -151,7 +120,29 @@ sha1.data.frame <- function(x, digits = 14L, zapsmall = 7L, ...){
             sha1,
             digits = digits,
             zapsmall = zapsmall,
-            ... = ...,
+            ...,
+            algo = algo,
+            FUN.VALUE = NA_character_
+        )
+    } else {
+        y <- x
+    }
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
+    )
+    digest(y, algo = algo)
+}
+
+sha1.list <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
+    if (length(x)) {
+        # needed to make results comparable between 32-bit and 64-bit
+        y <- vapply(
+            x,
+            sha1,
+            digits = digits,
+            zapsmall = zapsmall,
+            ...,
+            algo = algo,
             FUN.VALUE = NA_character_
         )
     } else {
@@ -163,59 +154,36 @@ sha1.data.frame <- function(x, digits = 14L, zapsmall = 7L, ...){
         zapsmall = as.integer(zapsmall),
         ... = ...
     )
-    digest(y, algo = "sha1")
+    digest(y, algo = algo)
 }
 
-sha1.list <- function(x, digits = 14L, zapsmall = 7L, ...){
-    if (length(x)) {
-        # needed to make results comparable between 32-bit and 64-bit
-        y <- vapply(
-            x,
-            sha1,
-            digits = digits,
-            zapsmall = zapsmall,
-            ... = ...,
-            FUN.VALUE = NA_character_
-        )
-    } else {
-        y <- x
-    }
-    attr(y, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
-    )
-    digest(y, algo = "sha1")
-}
-
-sha1.POSIXlt <- function(x, digits = 14L, zapsmall = 7L, ...) {
+sha1.POSIXlt <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     y <- do.call(
         data.frame,
         lapply(as.POSIXlt(x), unlist)
     )
     y$sec <- num2hex(y$sec, digits = digits, zapsmall = zapsmall)
-    attr(y, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    digest(y, algo = "sha1")
+    digest(y, algo = algo)
 }
 
-sha1.POSIXct <- function(x, digits = 14L, zapsmall = 7L, ...) {
-    y <- sha1(as.POSIXlt(x), digits = digits, zapsmall = zapsmall, ... = ...)
-    attr(y, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+sha1.POSIXct <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
+    y <- sha1(
+        as.POSIXlt(x),
+        digits = digits,
+        zapsmall = zapsmall,
+        ...,
+        algo = algo
     )
-    digest(y, algo = "sha1")
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
+    )
+    digest(y, algo = algo)
 }
 
-sha1.anova <- function(x, digits = 4L, zapsmall = 7L, ...){
+sha1.anova <- function(x, digits = 4L, zapsmall = 7L, ..., algo = "sha1"){
     if (digits > 4) {
         warning("Hash on 32 bit might be different from hash on 64 bit with digits > 4") # #nocov
     }
@@ -224,16 +192,32 @@ sha1.anova <- function(x, digits = 4L, zapsmall = 7L, ...){
         1,
         num2hex,
         digits = digits,
-        zapsmall = zapsmall,
-        ... = ...
+        zapsmall = zapsmall
     )
-    attr(y, "digest::sha1") <- list(
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
+    )
+    digest(y, algo = algo)
+}
+
+attr_sha1 <- function(x, digits, zapsmall, algo, ...) {
+    if (algo == "sha1") {
+        return(
+            list(
+                class = class(x),
+                digits = as.integer(digits),
+                zapsmall = as.integer(zapsmall),
+                ...
+            )
+        )
+    }
+    list(
         class = class(x),
         digits = as.integer(digits),
         zapsmall = as.integer(zapsmall),
-        ... = ...
+        algo = algo,
+        ...
     )
-    digest(y, algo = "sha1")
 }
 
 num2hex <- function(x, digits = 14L, zapsmall = 7L){
@@ -301,31 +285,29 @@ num2hex <- function(x, digits = 14L, zapsmall = 7L){
     return(output)
 }
 
-sha1.pairlist <- function(x, digits = 14L, zapsmall = 7L, ...) {
+sha1.pairlist <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     # needed to make results comparable between 32-bit and 64-bit
     y <- vapply(
         x,
         sha1,
         digits = digits,
         zapsmall = zapsmall,
-        ... = ...,
+        ...,
+        algo = algo,
         FUN.VALUE = NA_character_
     )
-    attr(y, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    digest(y, algo = "sha1")
+    digest(y, algo = algo)
 }
 
-sha1.name <- function(x, digits = 14L, zapsmall = 7L, ...) {
+sha1.name <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     # attribute cannot be set on a name object
-    digest(x, algo = "sha1")
+    digest(x, algo = algo)
 }
 
-sha1.function <- function(x, digits = 14L, zapsmall = 7L, ...){
+sha1.function <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
     dots <- list(...)
     if (is.null(dots$environment)) {
         dots$environment <- TRUE
@@ -334,7 +316,7 @@ sha1.function <- function(x, digits = 14L, zapsmall = 7L, ...){
         y <- list(
             formals = formals(x),
             body = as.character(body(x)),
-            environment = digest(environment(x), algo = "sha1")
+            environment = digest(environment(x), algo = algo)
         )
     } else {
         y <- list(
@@ -349,33 +331,25 @@ sha1.function <- function(x, digits = 14L, zapsmall = 7L, ...){
         zapsmall = zapsmall,
         environment = dots$environment,
         ... = dots,
+        algo = algo,
         FUN.VALUE = NA_character_
     )
-    attr(y, "digest::sha1") <- list(
-        class = class(y),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        dots
+    attr(y, "digest::sha1") <- attr_sha1(
+        x = y, digits = digits, zapsmall = zapsmall, algo = algo, dots
     )
-    digest(y, algo = "sha1")
+    digest(y, algo = algo)
 }
 
-sha1.call <- function(x, digits = 14L, zapsmall = 7L, ...){
-    attr(x, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+sha1.call <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
+    attr(x, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    digest(x, algo = "sha1")
+    digest(x, algo = algo)
 }
 
-sha1.raw <- function(x, digits = 14L, zapsmall = 7L, ...) {
-    attr(x, "digest::sha1") <- list(
-        class = class(x),
-        digits = as.integer(digits),
-        zapsmall = as.integer(zapsmall),
-        ... = ...
+sha1.raw <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
+    attr(x, "digest::sha1") <- attr_sha1(
+        x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
-    digest(x, algo = "sha1")
+    digest(x, algo = algo)
 }

--- a/R/sha1.R
+++ b/R/sha1.R
@@ -369,3 +369,13 @@ sha1.call <- function(x, digits = 14L, zapsmall = 7L, ...){
     )
     digest(x, algo = "sha1")
 }
+
+sha1.raw <- function(x, digits = 14L, zapsmall = 7L, ...) {
+    attr(x, "digest::sha1") <- list(
+        class = class(x),
+        digits = as.integer(digits),
+        zapsmall = as.integer(zapsmall),
+        ... = ...
+    )
+    digest(x, algo = "sha1")
+}

--- a/man/sha1.rd
+++ b/man/sha1.rd
@@ -20,29 +20,31 @@
 \alias{sha1.anova}
 \alias{sha1.function}
 \alias{sha1.call}
+\alias{sha1.raw}
 \title{Calculate a SHA1 hash of an object}
 \author{Thierry Onkelinx}
 \usage{
-sha1(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{integer}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{numeric}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{character}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{factor}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{complex}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{Date}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{NULL}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{logical}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{matrix}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{data.frame}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{array}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{list}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{pairlist}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{name}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{POSIXlt}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{POSIXct}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{anova}(x, digits = 4, zapsmall = 7, ...)
-\method{sha1}{function}(x, digits = 14, zapsmall = 7, ...)
-\method{sha1}{call}(x, digits = 14, zapsmall = 7, ...)
+sha1(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{integer}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{numeric}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{character}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{factor}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{complex}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{Date}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{NULL}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{logical}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{matrix}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{data.frame}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{array}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{list}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{pairlist}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{name}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{POSIXlt}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{POSIXct}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{anova}(x, digits = 4, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{function}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{call}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{raw}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
 }
 \arguments{
 \item{x}{the object to calculate the SHA1}
@@ -56,6 +58,9 @@ digit. Will be converted to a base 2 equivalent. Values smaller than this
 number are equivalent to 0. Defaults to \code{zapsmall = 7}}
 
 \item{...}{Ignored in most methods. See Details for usage}
+
+\item{algo}{The hashing algoritm to be used by \code{\link{digest}}. Defaults to
+"sha1"}
 }
 \description{
 Calculate a SHA1 hash of an object. The main difference with
@@ -71,4 +76,12 @@ Extra arguments:
 environment: An optional extra argument for \code{sha1.function}. Should
 be TRUE, FALSE or missing. \code{sha1.function} will ignore the enviroment of
 the function only when \code{environment = FALSE}.
+}
+\note{
+\code{sha1} gained an \code{algo} argument since version 0.6.15. This allows
+\code{sha1()} to use all hashing algoritms available in \code{digest()}. The
+hashes created with \code{sha1(x)} from digest >= 0.6.15 are identical to
+\code{sha1(x)} from digest <= 0.6.14. The only exceptions are hashes created
+with \code{sha1(x, algo = "sha1")}, they will be different starting from digest
+0.6.15
 }

--- a/tests/sha1Test.R
+++ b/tests/sha1Test.R
@@ -406,3 +406,17 @@ stopifnot(
         "93ab6a61f1a2ad50d4bf58396dc38cd3821b2eaf"
     )
 )
+
+x <- letters
+for (algo in c("md5", "sha1", "crc32", "sha256", "sha512", "xxhash32",
+               "xxhash64",  "murmur32")) {
+    y <- x
+    attr(y, "digest::sha1") <- digest:::attr_sha1(x, 14L, 7L, algo = algo)
+    stopifnot(
+        identical(
+            sha1(x, algo = algo),
+            digest(y, algo = algo)
+        )
+    )
+
+}

--- a/tests/sha1Test.R
+++ b/tests/sha1Test.R
@@ -400,3 +400,9 @@ stopifnot(
     )
 )
 
+stopifnot(
+    identical(
+        sha1(serialize("e13485e1b995f3e36d43674dcbfedea08ce237bc", NULL)),
+        "93ab6a61f1a2ad50d4bf58396dc38cd3821b2eaf"
+    )
+)

--- a/vignettes/sha1.Rmd
+++ b/vignettes/sha1.Rmd
@@ -143,17 +143,17 @@ lm_terms <- lm_SR$terms
 class(lm_model) # handled by sha1()
 class(lm_terms) # not handled by sha1()
 # define a method for formula
-sha1.formula <- function(x, digits = 14, zapsmall = 7){
-    sha1(as.character(x), digits = digits, zapsmall = zapsmall)
+sha1.formula <- function(x, digits = 14, zapsmall = 7, ..., algo = "sha1"){
+    sha1(as.character(x), digits = digits, zapsmall = zapsmall, algo = algo)
 }
 sha1(lm_terms)
 sha1(lm_model)
 # define a method for lm
-sha1.lm <- function(x, digits = 14, zapsmall = 7){
+sha1.lm <- function(x, digits = 14, zapsmall = 7, ..., algo = "sha1"){
     lm_model <- x$model
     lm_terms <- x$terms
     combined <- list(lm_model, lm_terms)
-    sha1(combined, digits = digits, zapsmall = zapsmall)
+    sha1(combined, digits = digits, zapsmall = zapsmall, ..., algo = algo)
 }
 sha1(lm_SR)
 sha1(lm_SR2)


### PR DESCRIPTION
As discussed in issue #72. One additional change is that sha1() also handles the raw class.

The hashes from `sha1(x)` remain identical. Unless the user for some reason used the (non-existing) `algo` argument in the past.