### PR TITLE
digest (>= 0.6.14) requires R (>= 3.0.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Implementation of a function 'digest()' for the creation
  widely tested) libraries such as 'OpenSSL' should be used.
 URL: http://dirk.eddelbuettel.com/code/digest.html
 BugReports: https://github.com/eddelbuettel/digest/issues
-Depends: R (>= 2.4.1)
+Depends: R (>= 3.1.0)
 License: GPL (>= 2)
 Suggests: knitr, rmarkdown
 VignetteBuilder: knitr


### PR DESCRIPTION
Due to CRAN policies, specifying R (>= 3.1.0).

## Example of current (R >= 2.4.1) specs 
Trying to install 'digest' on R 3.0.2 gives:
```sh
$ R CMD INSTALL digest_0.6.14.tar.gz 
* installing to library '/cbc/henrik/R/x86_64-unknown-linux-gnu-library/3.0'
* installing *source* package 'digest' ...
** package 'digest' successfully unpacked and MD5 sums checked
** libs
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c aes.c -o aes.o
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c crc32.c -o crc32.o
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c digest.c -o digest.o
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c init.c -o init.o
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c md5.c -o md5.o
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c pmurhash.c -o pmurhash.o
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c raes.c -o raes.o
raes.c: In function 'AESencryptECB':
raes.c:67: warning: implicit declaration of function 'MAYBE_REFERENCED'
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c sha1.c -o sha1.o
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c sha2.c -o sha2.o
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c sha256.c -o sha256.o
gcc -std=gnu99 -I/opt/R/R-3.0.2/lib64/R/include -DNDEBUG  -I/usr/local/include    -fpic  -g -O2  -c xxhash.c -o xxhash.o
gcc -std=gnu99 -shared -R/opt/NetCDF/NetCDF-4.3.0/lib -L/opt/NetCDF/NetCDF-4.3.0/lib -o digest.so aes.o crc32.o digest.o init.o md5.o pmurhash.o raes.o sha1.o sha2.o sha256.o xxhash.o -L/opt/gcc/gcc-4.9.2 -L/opt/R/R-3.0.2/lib64/R/lib -lR
gcc: unrecognized option '-R/opt/NetCDF/NetCDF-4.3.0/lib'
installing to /cbc/henrik/R/x86_64-unknown-linux-gnu-library/3.0/digest/libs
** R
** inst
** preparing package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded
Error in dyn.load(file, DLLpath = DLLpath, ...) : 
  unable to load shared object '/cbc/henrik/R/x86_64-unknown-linux-gnu-library/3.0/digest/libs/digest.so':
  /cbc/henrik/R/x86_64-unknown-linux-gnu-library/3.0/digest/libs/digest.so: undefined symbol: MAYBE_REFERENCED
Error: loading failed
Execution halted
ERROR: loading failed
* removing '/cbc/henrik/R/x86_64-unknown-linux-gnu-library/3.0/digest'
* restoring previous '/cbc/henrik/R/x86_64-unknown-linux-gnu-library/3.0/digest'
```


BTW, it works to install digest 0.6.13, e.g.
```sh
$ R CMD INSTALL digest_0.6.13.tar.gz
[...]
** building package indices ...
** testing if installed package can be loaded

* DONE (digest)

$
```
