### PR TITLE
This patch changes the SHA512 code to avoid faults from mis-aligned accesses

### DIFF
--- a/src/sha2.h
+++ b/src/sha2.h
@@ -122,12 +122,12 @@ typedef unsigned long long u_int64_t;	/* 8-bytes (64-bits) */
 typedef struct _SHA256_CTX {
 	uint32_t	state[8];
 	uint64_t	bitcount;
-	uint8_t	buffer[SHA256_BLOCK_LENGTH];
+	uint8_t	buffer[SHA256_BLOCK_LENGTH];  /* must be 32-bit aligned */
 } SHA256_CTX;
 typedef struct _SHA512_CTX {
 	uint64_t	state[8];
 	uint64_t	bitcount[2];
-	uint8_t	buffer[SHA512_BLOCK_LENGTH];
+	uint8_t	buffer[SHA512_BLOCK_LENGTH];  /* must be 64-bit aligned */
 } SHA512_CTX;
 
 #else /* SHA2_USE_INTTYPES_H */
@@ -135,12 +135,12 @@ typedef struct _SHA512_CTX {
 typedef struct _SHA256_CTX {
 	u_int32_t	state[8];
 	u_int64_t	bitcount;
-	u_int8_t	buffer[SHA256_BLOCK_LENGTH];
+	u_int8_t buffer[SHA256_BLOCK_LENGTH];  /* must be 32-bit aligned */
 } SHA256_CTX;
 typedef struct _SHA512_CTX {
 	u_int64_t	state[8];
 	u_int64_t	bitcount[2];
-	u_int8_t	buffer[SHA512_BLOCK_LENGTH];
+	u_int8_t buffer[SHA512_BLOCK_LENGTH];  /* must be 64-bit aligned */
 } SHA512_CTX;
 
 #endif /* SHA2_USE_INTTYPES_H */


### PR DESCRIPTION

In particular, such faults arise with R-3.5.1 and digest-0.6.16 on a
SPARC T2 system running Solaris 11 when compiled with gcc 4.9.2 in
32-bit mode, as illustrated below:

------------------------------------------------------------------------

R version 3.5.1 (2018-07-02) -- "Feather Spray"
Copyright (C) 2018 The R Foundation for Statistical Computing
Platform: sparc-sun-solaris2.11 (32-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> library(digest)
> txt <- ""
> for (i in 1:10) txt <- paste0(txt,"abcdefghijklmnopqrstuvwxyz")
> r <- digest(txt,alg="sha512",serialize=FALSE,skip=0)
> r <- digest(txt,alg="sha512",serialize=FALSE,skip=8)
> r <- digest(txt,alg="sha512",serialize=FALSE,skip=4)

 *** caught bus error ***
address 24cb07c, cause 'invalid alignment'

Traceback:
 1: digest(txt, alg = "sha512", serialize = FALSE, skip = 4)
An irrecoverable exception occurred. R is aborting now ...
Bus Error (core dumped)

------------------------------------------------------------------------

Whether the problem occurs varies with the compiler used, since some
SPARC instructions require alignment and others do not (so depends on
which instructions the compiler chooses).  The problem presumably also
occurs on other platforms with alignment requirements.  (Perhaps some
ARM systems?)

The fix is made to sha2.[ch], which is used for SHA512. There is an
analogous problem with the SHA256 code in those files, which is also
fixed (untested) in this patch, but it is in any case not enabled in
the 'digest' package (which uses other code for SHA256).

The issue is in the SHA512_Transform function, which is used locally
in sha2.c.  It is declared as

   void SHA512_Transform(SHA512_CTX* context, const sha2_word64* data)

Alignment faults may arise when it is called as

   SHA512_Transform(context, (sha2_word64*)data);

since 'data' may not be 64-bit aligned.  It is also called as

   SHA512_Transform(context, (sha2_word64*)context->buffer);

which does not produce a fault because context-buffer happens to be
64-bit aligned.  This call does, however, violate the 'const'
attribute in the prototype, since context->buffer is written to inside
SHA512_Transform.  (This aliasing violates the C standard, but is
unlikely to actually cause a bug.)

This patch modifies SHA512_Transform so it is declared as

   static void SHA512_Transform(SHA512_CTX* context)

with data always coming from context->buffer.  The previous call with
'data' as the second argument is replaced by

   MEMCPY_BCOPY(context->buffer, data, SHA256_BLOCK_LENGTH);
   SHA256_Transform(context);

The copy should handled any alignment for 'data'.

There is no measurable performance impact.