### PR TITLE
Noticed wrong placement of a bracket

### DIFF
--- a/inst/tinytest/test_num2hex.R
+++ b/inst/tinytest/test_num2hex.R
@@ -30,8 +30,8 @@ exponent <-  unique(gsub("^[0-9a-f]* ", "", x.hex))
 expect_equal(length(exponent), 1L)
 
 mantissa <- gsub(" [0-9]*$", "", x.hex)
-ignore(expect_true(all(
-    lapply(
+ignore(expect_true)(all(
+    sapply(
         head(seq_along(mantissa), -1),
         function(i){
             all(
@@ -42,7 +42,7 @@ ignore(expect_true(all(
             )
         }
     )
-)))
+))
 
 #it keeps NA values
 x <- c(pi, NA, 0)


### PR DESCRIPTION
to `ignore` the result of a test (i.e. to not record it in the test results) use `ignore(expect_something)(arguments here)`