### PR TITLE
add a vectorised digest function

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -5,7 +5,7 @@ useDynLib(digest, digest_impl=digest, vdigest_impl=vdigest, digest2int_impl=dige
 export(AES,
        digest,
        digest2int,
-       set_vdigest,
+       getVDigest,
        sha1,
        hmac,
        makeRaw)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,10 +1,11 @@
 ## package has a dynamic library
-useDynLib(digest, digest_impl=digest, digest2int_impl=digest2int, AESinit, AESencryptECB, AESdecryptECB, spookydigest_impl, .registration=TRUE)
+useDynLib(digest, digest_impl=digest, vdigest_impl=vdigest, digest2int_impl=digest2int, AESinit, AESencryptECB, AESdecryptECB, spookydigest_impl, .registration=TRUE)
 
 ## and exported functions
 export(AES,
        digest,
        digest2int,
+       set_vdigest,
        sha1,
        hmac,
        makeRaw)

--- a/R/vdigest.R
+++ b/R/vdigest.R
@@ -1,5 +1,5 @@
 
-set_vdigest <- function(algo = c("md5", "sha1", "crc32", "sha256", "sha512",
+getVDigest <- function(algo = c("md5", "sha1", "crc32", "sha256", "sha512",
                                  "xxhash32", "xxhash64", "murmur32", "spookyhash"),
                         errormode=c("stop","warn","silent")){
     algo <- match.arg(algo)

--- a/R/vdigest.R
+++ b/R/vdigest.R
@@ -1,10 +1,18 @@
 
-
 set_vdigest <- function(algo = c("md5", "sha1", "crc32", "sha256", "sha512",
                                  "xxhash32", "xxhash64", "murmur32", "spookyhash"),
                         errormode=c("stop","warn","silent")){
     algo <- match.arg(algo)
     errormode <- match.arg(errormode)
+    algoint <- algo_int(algo)
+    non_streaming_algos <- c("md5", "sha1", "crc32", "sha256", "sha512",
+                             "xxhash32", "xxhash64", "murmur32")
+    if (algo %in% non_streaming_algos)
+        return(non_streaming_digest(algo, errormode, algoint))
+    streaming_digest(algo, errormode, algoint)
+}
+
+non_streaming_digest <- function(algo, errormode, algoint){
     function(object,
              serialize=TRUE,
              file=FALSE,
@@ -14,51 +22,36 @@ set_vdigest <- function(algo = c("md5", "sha1", "crc32", "sha256", "sha512",
              seed=0,
              serializeVersion=.getSerializeVersion()){
 
-        if (is.infinite(length)) {
+        if (is.infinite(length))
             length <- -1               # internally we use -1 for infinite len
-        }
 
         if (is.character(file) && missing(object)) {
             object <- file                  # nocov
             file <- TRUE                  	# nocov
         }
 
-        streaming_algos <- c("spookyhash")
-        non_streaming_algos <- c("md5", "sha1", "crc32", "sha256", "sha512",
-                                 "xxhash32", "xxhash64", "murmur32")
-        if(algo %in% streaming_algos && !serialize){
-            .errorhandler(paste0(algo, " algorithm is not available without serialization."),  # #nocov
-                          mode=errormode)                                                      # #nocov
-        }
-
         if (serialize && !file) {
-
-            if(algo %in% non_streaming_algos){
-                ## support the 'nosharing' option in pqR's base::serialize()
-                object <- if ("nosharing" %in% names(formals(base::serialize)))
-                    serialize_(object, connection=NULL, ascii=ascii,
-                               nosharing=TRUE, version=serializeVersion)
-                else
-                    serialize_(object, connection=NULL, ascii=ascii,version=serializeVersion)
-            }
+            ## support the 'nosharing' option in pqR's base::serialize()
+            object <- if ("nosharing" %in% names(formals(base::serialize)))
+                serialize_(
+                    object,
+                    connection = NULL,
+                    ascii = ascii,
+                    nosharing = TRUE,
+                    version = serializeVersion
+                )
+            else
+                serialize_(object,
+                           connection = NULL,
+                           ascii = ascii,
+                           version = serializeVersion)
             ## we support raw vectors, so no mangling of 'object' is necessary
             ## regardless of R version
             ## skip="auto" - skips the serialization header [SU]
-            if (any(!is.na(pmatch(skip,"auto")))) {
-                if (ascii) {
-                    ## HB 14 Mar 2007:
-                    ## Exclude serialization header (non-data dependent bytes but R
-                    ## version specific).  In ASCII, the header consists of for rows
-                    ## ending with a newline ('\n').  We need to skip these.
-                    ## The end of 4th row is *typically* within the first 18 bytes
-                    skip <- which(object[1:30] == as.raw(10))[4] # nocov
-                } else {
-                    skip <- 14
-                }
-                ## Was: skip <- if (ascii) 18 else 14
-            }
-        } else if (!is.character(object) && !inherits(object,"raw") &&
-                   algo %in% non_streaming_algos) {
+            if (any(!is.na(pmatch(skip,"auto"))))
+                skip <- set_skip(object, ascii)
+
+        } else if (!is.character(object) && !inherits(object,"raw")) {
             return(.errorhandler(paste("Argument object must be of type character",	  # #nocov
                                        "or raw vector if serialize is FALSE"), mode=errormode)) # #nocov
         }
@@ -66,51 +59,78 @@ set_vdigest <- function(algo = c("md5", "sha1", "crc32", "sha256", "sha512",
             return(.errorhandler("file=TRUE can only be used with a character object",          # #nocov
                                  mode=errormode))                                               # #nocov
 
-        if (file && algo %in% streaming_algos)
-            return(.errorhandler(paste0(algo, " algorithm can not be used with files."),        # #nocov
-                                 mode=errormode))                                               # #nocov
-
-        ## HB 14 Mar 2007:  null op, only turned to char if alreadt char
-        ##if (!inherits(object,"raw"))
-        ##  object <- as.character(object)
-        algoint <- switch(algo,
-                          md5=1,
-                          sha1=2,
-                          crc32=3,
-                          sha256=4,
-                          sha512=5,
-                          xxhash32=6,
-                          xxhash64=7,
-                          murmur32=8,
-                          spookyhash=9)
         if (file) {
             algoint <- algoint+100
             object <- path.expand(object)
-            if (!file.exists(object)) {
-                return(.errorhandler("The file does not exist: ", object, mode=errormode)) # nocov
-            }
-            if (!isTRUE(!file.info(object)$isdir)) {
-                return(.errorhandler("The specified pathname is not a file: ", # nocov
-                                     object, mode=errormode))                  # nocov
-            }
-            if (file.access(object, 4)) {
-                return(.errorhandler("The specified file is not readable: ",   # #nocov
-                                     object, mode=errormode))                  # #nocov
-            }
+            check_file(object, errormode)
         }
         ## if skip is auto (or any other text for that matter), we just turn it
         ## into 0 because auto should have been converted into a number earlier
         ## if it was valid [SU]
         if (is.character(skip)) skip <- 0
-        if(algo %in% non_streaming_algos){
-            val <- .Call(vdigest_impl,
-                         object,
-                         as.integer(algoint),
-                         as.integer(length),
-                         as.integer(skip),
-                         0L, # raw always FALSE
-                         as.integer(seed))
-        } else if (algo == "spookyhash"){
+        val <- .Call(
+            vdigest_impl,
+            object,
+            as.integer(algoint),
+            as.integer(length),
+            as.integer(skip),
+            0L, # raw always FALSE
+            as.integer(seed)
+        )
+        ## crc32 output was not guaranteed to be eight chars long, which we corrected
+        ## this allows to get the old behaviour back for compatibility
+        if ((algoint == 3 || algoint == 103) && .getCRC32PreferOldOutput()) {
+            val <- sub("^0+", "", val)
+        }
+
+        return(val)
+    }
+}
+
+streaming_digest <- function(algo, errormode, algoint){
+    function(object,
+             serialize=TRUE,
+             file=FALSE,
+             length=Inf,
+             skip="auto",
+             ascii=FALSE,
+             seed=0,
+             serializeVersion=.getSerializeVersion()){
+
+        if (is.infinite(length))
+            length <- -1               # internally we use -1 for infinite len
+
+        if (is.character(file) && missing(object)) {
+            object <- file                  # nocov
+            file <- TRUE                  	# nocov
+        }
+
+        if (!serialize){
+            .errorhandler(paste0(algo, " algorithm is not available without serialization."),  # #nocov
+                          mode=errormode)                                                      # #nocov
+        }
+
+        if (serialize && !file) {
+            ## we support raw vectors, so no mangling of 'object' is necessary
+            ## regardless of R version
+            ## skip="auto" - skips the serialization header [SU]
+            if (any(!is.na(pmatch(skip,"auto"))))
+                skip <- set_skip(object, ascii)
+        }
+        if (file)
+            return(.errorhandler(paste0(algo, " algorithm can not be used with files."),        # #nocov
+                                 mode=errormode))                                               # #nocov
+
+        if (file) {
+            algoint <- algoint+100
+            object <- path.expand(object)
+            check_file(object, errormode)
+        }
+        ## if skip is auto (or any other text for that matter), we just turn it
+        ## into 0 because auto should have been converted into a number earlier
+        ## if it was valid [SU]
+        if (is.character(skip)) skip <- 0
+        if (algo == "spookyhash"){
             # 0s are the seeds. They are included to enable testing against fastdigest.
             val <- vapply(object,
                           function(o)
@@ -141,7 +161,7 @@ serialize_ <- function(object, ...){
 .errorhandler <- function(txt, obj="", mode="stop") {
     if (mode == "stop") {
         stop(txt, obj, call.=FALSE)
-    } else if (mode == "warn") {	  # #nocov
+    } else if (mode == "warn") {	    # nocov
         warning(txt, obj, call.=FALSE)  # nocov
         return(invisible(NA))           # nocov
     } else {
@@ -149,3 +169,42 @@ serialize_ <- function(object, ...){
     }
 }
 
+algo_int <- function(algo)
+    switch(
+        algo,
+        md5 = 1,
+        sha1 = 2,
+        crc32 = 3,
+        sha256 = 4,
+        sha512 = 5,
+        xxhash32 = 6,
+        xxhash64 = 7,
+        murmur32 = 8,
+        spookyhash = 9
+    )
+
+## HB 14 Mar 2007:
+## Exclude serialization header (non-data dependent bytes but R
+## version specific).  In ASCII, the header consists of for rows
+## ending with a newline ('\n').  We need to skip these.
+## The end of 4th row is *typically* within the first 18 bytes
+set_skip <- function(object, ascii){
+    if (!ascii)
+        return(14)
+    ## Was: skip <- if (ascii) 18 else 14
+    which(object[1:30] == as.raw(10))[4]
+}
+
+check_file <- function(object, errormode){
+    if (!file.exists(object)) {
+        return(.errorhandler("The file does not exist: ", object, mode=errormode)) # nocov
+    }
+    if (!isTRUE(!file.info(object)$isdir)) {
+        return(.errorhandler("The specified pathname is not a file: ", # nocov
+                             object, mode=errormode))                  # nocov
+    }
+    if (file.access(object, 4)) {
+        return(.errorhandler("The specified file is not readable: ",   # #nocov
+                             object, mode=errormode))                  # #nocov
+    }
+}

--- a/R/vdigest.R
+++ b/R/vdigest.R
@@ -117,15 +117,12 @@ streaming_digest <- function(algo, errormode, algoint){
             if (any(!is.na(pmatch(skip,"auto"))))
                 skip <- set_skip(object, ascii)
         }
+
         if (file)
             return(.errorhandler(paste0(algo, " algorithm can not be used with files."),        # #nocov
                                  mode=errormode))                                               # #nocov
 
-        if (file) {
-            algoint <- algoint+100
-            object <- path.expand(object)
-            check_file(object, errormode)
-        }
+
         ## if skip is auto (or any other text for that matter), we just turn it
         ## into 0 because auto should have been converted into a number earlier
         ## if it was valid [SU]

--- a/R/vdigest.R
+++ b/R/vdigest.R
@@ -1,0 +1,151 @@
+
+
+set_vdigest <- function(algo = c("md5", "sha1", "crc32", "sha256", "sha512",
+                                 "xxhash32", "xxhash64", "murmur32", "spookyhash"),
+                        errormode=c("stop","warn","silent")){
+    algo <- match.arg(algo)
+    errormode <- match.arg(errormode)
+    function(object,
+             serialize=TRUE,
+             file=FALSE,
+             length=Inf,
+             skip="auto",
+             ascii=FALSE,
+             seed=0,
+             serializeVersion=.getSerializeVersion()){
+
+        if (is.infinite(length)) {
+            length <- -1               # internally we use -1 for infinite len
+        }
+
+        if (is.character(file) && missing(object)) {
+            object <- file                  # nocov
+            file <- TRUE                  	# nocov
+        }
+
+        streaming_algos <- c("spookyhash")
+        non_streaming_algos <- c("md5", "sha1", "crc32", "sha256", "sha512",
+                                 "xxhash32", "xxhash64", "murmur32")
+        if(algo %in% streaming_algos && !serialize){
+            .errorhandler(paste0(algo, " algorithm is not available without serialization."),  # #nocov
+                          mode=errormode)                                                      # #nocov
+        }
+
+        if (serialize && !file) {
+
+            if(algo %in% non_streaming_algos){
+                ## support the 'nosharing' option in pqR's base::serialize()
+                object <- if ("nosharing" %in% names(formals(base::serialize)))
+                    serialize_(object, connection=NULL, ascii=ascii,
+                               nosharing=TRUE, version=serializeVersion)
+                else
+                    serialize_(object, connection=NULL, ascii=ascii,version=serializeVersion)
+            }
+            ## we support raw vectors, so no mangling of 'object' is necessary
+            ## regardless of R version
+            ## skip="auto" - skips the serialization header [SU]
+            if (any(!is.na(pmatch(skip,"auto")))) {
+                if (ascii) {
+                    ## HB 14 Mar 2007:
+                    ## Exclude serialization header (non-data dependent bytes but R
+                    ## version specific).  In ASCII, the header consists of for rows
+                    ## ending with a newline ('\n').  We need to skip these.
+                    ## The end of 4th row is *typically* within the first 18 bytes
+                    skip <- which(object[1:30] == as.raw(10))[4] # nocov
+                } else {
+                    skip <- 14
+                }
+                ## Was: skip <- if (ascii) 18 else 14
+            }
+        } else if (!is.character(object) && !inherits(object,"raw") &&
+                   algo %in% non_streaming_algos) {
+            return(.errorhandler(paste("Argument object must be of type character",	  # #nocov
+                                       "or raw vector if serialize is FALSE"), mode=errormode)) # #nocov
+        }
+        if (file && !is.character(object))
+            return(.errorhandler("file=TRUE can only be used with a character object",          # #nocov
+                                 mode=errormode))                                               # #nocov
+
+        if (file && algo %in% streaming_algos)
+            return(.errorhandler(paste0(algo, " algorithm can not be used with files."),        # #nocov
+                                 mode=errormode))                                               # #nocov
+
+        ## HB 14 Mar 2007:  null op, only turned to char if alreadt char
+        ##if (!inherits(object,"raw"))
+        ##  object <- as.character(object)
+        algoint <- switch(algo,
+                          md5=1,
+                          sha1=2,
+                          crc32=3,
+                          sha256=4,
+                          sha512=5,
+                          xxhash32=6,
+                          xxhash64=7,
+                          murmur32=8,
+                          spookyhash=9)
+        if (file) {
+            algoint <- algoint+100
+            object <- path.expand(object)
+            if (!file.exists(object)) {
+                return(.errorhandler("The file does not exist: ", object, mode=errormode)) # nocov
+            }
+            if (!isTRUE(!file.info(object)$isdir)) {
+                return(.errorhandler("The specified pathname is not a file: ", # nocov
+                                     object, mode=errormode))                  # nocov
+            }
+            if (file.access(object, 4)) {
+                return(.errorhandler("The specified file is not readable: ",   # #nocov
+                                     object, mode=errormode))                  # #nocov
+            }
+        }
+        ## if skip is auto (or any other text for that matter), we just turn it
+        ## into 0 because auto should have been converted into a number earlier
+        ## if it was valid [SU]
+        if (is.character(skip)) skip <- 0
+        if(algo %in% non_streaming_algos){
+            val <- .Call(vdigest_impl,
+                         object,
+                         as.integer(algoint),
+                         as.integer(length),
+                         as.integer(skip),
+                         0L, # raw always FALSE
+                         as.integer(seed))
+        } else if (algo == "spookyhash"){
+            # 0s are the seeds. They are included to enable testing against fastdigest.
+            val <- vapply(object,
+                          function(o)
+                              paste(
+                                  .Call(spookydigest_impl, o, skip, 0, 0, serializeVersion),
+                                  collapse = ""
+                              ),
+                          character(1),
+                          USE.NAMES = FALSE)
+        }
+
+        ## crc32 output was not guaranteed to be eight chars long, which we corrected
+        ## this allows to get the old behaviour back for compatibility
+        if ((algoint == 3 || algoint == 103) && .getCRC32PreferOldOutput()) {
+            val <- sub("^0+", "", val)
+        }
+
+        return(val)
+    }
+}
+
+serialize_ <- function(object, ...){
+    if (length(object))
+        return(lapply(object, base::serialize, ...))
+    base::serialize(object, ...)
+}
+
+.errorhandler <- function(txt, obj="", mode="stop") {
+    if (mode == "stop") {
+        stop(txt, obj, call.=FALSE)
+    } else if (mode == "warn") {	  # #nocov
+        warning(txt, obj, call.=FALSE)  # nocov
+        return(invisible(NA))           # nocov
+    } else {
+        return(invisible(NULL))         # nocov
+    }
+}
+

--- a/demo/00Index
+++ b/demo/00Index
@@ -1,0 +1,1 @@
+vectorised              Timing comparison of approaches for vectorised digest

--- a/demo/vectorised.R
+++ b/demo/vectorised.R
@@ -1,0 +1,34 @@
+library(digest)
+
+#vectorisation
+md5 <- getVDigest()
+digest2 <- base::Vectorize(digest)
+x <- rep(letters, 1e3)
+rbenchmark::benchmark(
+    vdigest = md5(x, serialize = FALSE),
+    Vectorize = digest2(x, serialize = FALSE),
+    vapply = vapply(x, digest, character(1), serialize = FALSE),
+    replications = 5
+)[,1:4]
+all(md5(x, serialize=FALSE) == digest2(x, serialize=FALSE))
+all(md5(x, serialize=FALSE) == vapply(x, digest, character(1), serialize = FALSE))
+
+#repeated calls
+stretch_key <- function(d, n) {
+    md5 <- getVDigest()
+    for (i in seq_len(n))
+        d <- md5(d, serialize = FALSE)
+    d
+}
+
+stretch_key2 <- function(d, n) {
+    for (i in seq_len(n))
+        d <- digest(d, serialize = FALSE)
+    d
+}
+rbenchmark::benchmark(
+    vdigest = stretch_key('abc123', 65e3),
+    plaindigest = stretch_key2('abc123', 65e3),
+    replications = 10
+)[,1:4]
+stretch_key('abc123', 65e3) == stretch_key2('abc123', 65e3)

--- a/inst/tinytest/test_digest.R
+++ b/inst/tinytest/test_digest.R
@@ -28,6 +28,21 @@ for (i in seq(along.with=md5Input)) {
     #cat(md5, "\n")
 }
 
+md5 <- set_vdigest()
+expect_identical(md5(md5Input, serialize = FALSE), md5Output)
+
+expect_identical(digest(NULL),
+                 md5(NULL))
+expect_identical(digest(character(0)),
+                 md5(character(0)))
+expect_identical(digest(list("abc")),
+                 md5(list(list("abc"))))
+expect_identical(digest(list(NULL)),
+                 md5(list(list(NULL))))
+expect_identical(digest(character(0), serialize = FALSE),
+                 md5(character(0), serialize = FALSE))
+
+
 ## md5 raw output test
 for (i in seq(along.with=md5Input)) {
     md5 <- digest(md5Input[i], serialize=FALSE, raw=TRUE)
@@ -51,6 +66,9 @@ for (i in seq(along.with=sha1Input)) {
     #cat(sha1, "\n")
 }
 
+sha1 <- set_vdigest(algo = 'sha1')
+expect_identical(sha1(sha1Input, serialize = FALSE), sha1Output[1:2])
+
 ## sha1 raw output test
 for (i in seq(along.with=sha1Input)) {
     sha1 <- digest(sha1Input[i], algo="sha1", serialize=FALSE, raw=TRUE)
@@ -61,7 +79,6 @@ for (i in seq(along.with=sha1Input)) {
     expect_true(identical(sha1, sha1Output[i]))
     #cat(sha1, "\n")
 }
-
 
 ## sha512 test
 sha512Input <-c(
@@ -78,6 +95,9 @@ for (i in seq(along.with=sha512Input)) {
     #cat(sha512, "\n")
 }
 
+sha512 <- set_vdigest(algo = 'sha512')
+expect_identical(sha512(sha512Input, serialize = FALSE), sha512Output[1:2])
+
 ## sha512 raw output test
 for (i in seq(along.with=sha512Input)) {
     sha512 <- digest(sha512Input[i], algo="sha512", serialize=FALSE, raw=TRUE)
@@ -89,8 +109,6 @@ for (i in seq(along.with=sha512Input)) {
     expect_true(identical(sha512, sha512Output[i]))
     #cat(sha512, "\n")
 }
-
-
 
 crc32Input <-
     c("abc",
@@ -106,6 +124,10 @@ for (i in seq(along.with=crc32Input)) {
     expect_true(identical(crc32, crc32Output[i]))
     #cat(crc32, "\n")
 }
+
+crc32 <- set_vdigest(algo = 'crc32')
+expect_identical(crc32(crc32Input, serialize = FALSE), crc32Output[1:2])
+
 
 ## one of the FIPS-
 sha1 <- digest("abc", algo="sha1", serialize=FALSE)
@@ -134,6 +156,10 @@ for (i in seq(along.with=xxhash32Input)) {
     expect_true(identical(xxhash32, xxhash32Output[i]))
 }
 
+xxhash32 <- set_vdigest(algo = 'xxhash32')
+expect_identical(xxhash32(xxhash32Input, serialize = FALSE), xxhash32Output)
+
+
 ## these outputs were calculated using xxh64sum
 xxhash64Input <-
     c("abc",
@@ -149,6 +175,10 @@ for (i in seq(along.with=xxhash64Input)) {
     #cat(xxhash64, "\n")
     expect_true(identical(xxhash64, xxhash64Output[i]))
 }
+
+xxhash64 <- set_vdigest(algo = 'xxhash64')
+expect_identical(xxhash64(xxhash64Input, serialize = FALSE), xxhash64Output)
+
 
 ## these outputs were calculated using mmh3 python package
 ## the first two are also shown at this StackOverflow question on test vectors
@@ -167,6 +197,10 @@ for (i in seq(along.with=murmur32Input)) {
     #cat(murmur32, "\n")
     expect_true(identical(murmur32, murmur32Output[i]))
 }
+
+murmur32 <- set_vdigest(algo = 'murmur32')
+expect_identical(murmur32(murmur32Input, serialize = FALSE), murmur32Output)
+
 
 ## tests for digest spooky
 
@@ -227,6 +261,11 @@ for (i in seq(along.with=spookyInput)) {
   #cat(spooky, "\n")
 }
 
+expect_identical(
+  set_vdigest(algo = 'spookyhash')(spookyInput, skip = 30),
+  spookyOutputPython
+)
+
 ## some extras to get coverage up - these aren't tested against reference output,
 ## just output from R 3.6.0
 spookyInput <- c("a", "aaaaaaaaa", "aaaaaaaaaaaaa")
@@ -241,9 +280,16 @@ for (i in seq(along.with=spookyInput)) {
   #cat(spooky, "\n")
 }
 
+expect_identical(
+  set_vdigest(algo = 'spookyhash')(spookyInput),
+  spookyOutput
+)
+
 # test a bigger object
 spooky <- digest(iris, algo = "spookyhash")
 expect_true(identical(spooky, "af58add8b4f7044582b331083bc239ff"))
+expect_identical(set_vdigest('spookyhash')(list(iris)),
+                 "af58add8b4f7044582b331083bc239ff")
 #cat(spooky, "\n")
 
 # test error message
@@ -266,15 +312,28 @@ for (alg in c("sha1", "md5", "crc32", "sha256", "sha512",
     h3 <- digest(substr(x,1,18000)  , algo=alg, serialize=FALSE)
     expect_true(identical(h1,h3))
     #cat(h1, "\n", h2, "\n", h3, "\n")
+    expect_identical(
+      set_vdigest(alg)(x, length = 18e3, serialize = FALSE),
+      set_vdigest(alg)(fname, length = 18e3, serialize = FALSE, file = TRUE)
+    )
                                         # whole file
     h4 <- digest(x    , algo=alg, serialize=FALSE)
     h5 <- digest(fname, algo=alg, serialize=FALSE, file=TRUE)
     expect_true( identical(h4,h5) )
 
+    expect_identical(
+      set_vdigest(alg)(x, serialize = FALSE),
+      set_vdigest(alg)(fname, serialize = FALSE, file = TRUE)
+    )
+
     ## Assert that 'skip' works
     h6 <- digest(xskip, algo=alg, serialize=FALSE)
     h7 <- digest(fname, algo=alg, serialize=FALSE, skip=20, file=TRUE)
     expect_true( identical(h6, h7) )
+    expect_identical(
+      set_vdigest(alg)(xskip, serialize = FALSE),
+      set_vdigest(alg)(fname, serialize = FALSE, skip = 20, file = TRUE)
+    )
 }
 
 ## compare md5 algorithm to other tools

--- a/inst/tinytest/test_digest.R
+++ b/inst/tinytest/test_digest.R
@@ -28,7 +28,7 @@ for (i in seq(along.with=md5Input)) {
     #cat(md5, "\n")
 }
 
-md5 <- set_vdigest()
+md5 <- getVDigest()
 expect_identical(md5(md5Input, serialize = FALSE), md5Output)
 
 expect_identical(digest(NULL),
@@ -66,7 +66,7 @@ for (i in seq(along.with=sha1Input)) {
     #cat(sha1, "\n")
 }
 
-sha1 <- set_vdigest(algo = 'sha1')
+sha1 <- getVDigest(algo = 'sha1')
 expect_identical(sha1(sha1Input, serialize = FALSE), sha1Output[1:2])
 
 ## sha1 raw output test
@@ -95,7 +95,7 @@ for (i in seq(along.with=sha512Input)) {
     #cat(sha512, "\n")
 }
 
-sha512 <- set_vdigest(algo = 'sha512')
+sha512 <- getVDigest(algo = 'sha512')
 expect_identical(sha512(sha512Input, serialize = FALSE), sha512Output[1:2])
 
 ## sha512 raw output test
@@ -125,7 +125,7 @@ for (i in seq(along.with=crc32Input)) {
     #cat(crc32, "\n")
 }
 
-crc32 <- set_vdigest(algo = 'crc32')
+crc32 <- getVDigest(algo = 'crc32')
 expect_identical(crc32(crc32Input, serialize = FALSE), crc32Output[1:2])
 
 
@@ -156,7 +156,7 @@ for (i in seq(along.with=xxhash32Input)) {
     expect_true(identical(xxhash32, xxhash32Output[i]))
 }
 
-xxhash32 <- set_vdigest(algo = 'xxhash32')
+xxhash32 <- getVDigest(algo = 'xxhash32')
 expect_identical(xxhash32(xxhash32Input, serialize = FALSE), xxhash32Output)
 
 
@@ -176,7 +176,7 @@ for (i in seq(along.with=xxhash64Input)) {
     expect_true(identical(xxhash64, xxhash64Output[i]))
 }
 
-xxhash64 <- set_vdigest(algo = 'xxhash64')
+xxhash64 <- getVDigest(algo = 'xxhash64')
 expect_identical(xxhash64(xxhash64Input, serialize = FALSE), xxhash64Output)
 
 
@@ -198,7 +198,7 @@ for (i in seq(along.with=murmur32Input)) {
     expect_true(identical(murmur32, murmur32Output[i]))
 }
 
-murmur32 <- set_vdigest(algo = 'murmur32')
+murmur32 <- getVDigest(algo = 'murmur32')
 expect_identical(murmur32(murmur32Input, serialize = FALSE), murmur32Output)
 
 
@@ -262,7 +262,7 @@ for (i in seq(along.with=spookyInput)) {
 }
 
 expect_identical(
-  set_vdigest(algo = 'spookyhash')(spookyInput, skip = 30),
+  getVDigest(algo = 'spookyhash')(spookyInput, skip = 30),
   spookyOutputPython
 )
 
@@ -281,14 +281,14 @@ for (i in seq(along.with=spookyInput)) {
 }
 
 expect_identical(
-  set_vdigest(algo = 'spookyhash')(spookyInput),
+  getVDigest(algo = 'spookyhash')(spookyInput),
   spookyOutput
 )
 
 # test a bigger object
 spooky <- digest(iris, algo = "spookyhash")
 expect_true(identical(spooky, "af58add8b4f7044582b331083bc239ff"))
-expect_identical(set_vdigest('spookyhash')(list(iris)),
+expect_identical(getVDigest('spookyhash')(list(iris)),
                  "af58add8b4f7044582b331083bc239ff")
 #cat(spooky, "\n")
 
@@ -313,8 +313,8 @@ for (alg in c("sha1", "md5", "crc32", "sha256", "sha512",
     expect_true(identical(h1,h3))
     #cat(h1, "\n", h2, "\n", h3, "\n")
     expect_identical(
-      set_vdigest(alg)(x, length = 18e3, serialize = FALSE),
-      set_vdigest(alg)(fname, length = 18e3, serialize = FALSE, file = TRUE)
+      getVDigest(alg)(x, length = 18e3, serialize = FALSE),
+      getVDigest(alg)(fname, length = 18e3, serialize = FALSE, file = TRUE)
     )
                                         # whole file
     h4 <- digest(x    , algo=alg, serialize=FALSE)
@@ -322,8 +322,8 @@ for (alg in c("sha1", "md5", "crc32", "sha256", "sha512",
     expect_true( identical(h4,h5) )
 
     expect_identical(
-      set_vdigest(alg)(x, serialize = FALSE),
-      set_vdigest(alg)(fname, serialize = FALSE, file = TRUE)
+      getVDigest(alg)(x, serialize = FALSE),
+      getVDigest(alg)(fname, serialize = FALSE, file = TRUE)
     )
 
     ## Assert that 'skip' works
@@ -331,8 +331,8 @@ for (alg in c("sha1", "md5", "crc32", "sha256", "sha512",
     h7 <- digest(fname, algo=alg, serialize=FALSE, skip=20, file=TRUE)
     expect_true( identical(h6, h7) )
     expect_identical(
-      set_vdigest(alg)(xskip, serialize = FALSE),
-      set_vdigest(alg)(fname, serialize = FALSE, skip = 20, file = TRUE)
+      getVDigest(alg)(xskip, serialize = FALSE),
+      getVDigest(alg)(fname, serialize = FALSE, skip = 20, file = TRUE)
     )
 }
 

--- a/man/digest.Rd
+++ b/man/digest.Rd
@@ -320,10 +320,10 @@ h2 <- digest(fname, algo="md5", file=TRUE)
 stopifnot( identical(h1,h2) )
 
 ## digest is _designed_ to return one has summary per object to for a desired
-## For vectorised output see digest::set_vdigest() which provides
+## For vectorised output see digest::getVDigest() which provides
 ## better performance than base::Vectorize()
 
-md5 <- set_vdigest()
+md5 <- getVDigest()
 v <- md5(1:5)     			# digest integers 1 to 5
 stopifnot(identical(v[1], digest(1L)),	# check first and third result
           identical(v[3], digest(3L)))

--- a/man/digest.Rd
+++ b/man/digest.Rd
@@ -320,10 +320,11 @@ h2 <- digest(fname, algo="md5", file=TRUE)
 stopifnot( identical(h1,h2) )
 
 ## digest is _designed_ to return one has summary per object to for a desired
-## vector of digests you need to explicitly loop, which Vectorize() can do for
-## you -- see this nice SO answer: https://stackoverflow.com/a/28360092/143305
-vdigest <- Vectorize(digest)
-v <- vdigest(1:5)     			# digest integers 1 to 5
+## For vectorised output see digest::set_vdigest() which provides
+## better performance than base::Vectorize()
+
+md5 <- set_vdigest()
+v <- md5(1:5)     			# digest integers 1 to 5
 stopifnot(identical(v[1], digest(1L)),	# check first and third result
           identical(v[3], digest(3L)))
 

--- a/man/vdigest.Rd
+++ b/man/vdigest.Rd
@@ -1,13 +1,13 @@
-\name{set_vdigest}
-\alias{set_vdigest}
+\name{getVDigest}
+\alias{getVDigest}
 \title{Set a vectorised function for creating hash function digests}
 \description{
-The \code{set_vdigest} function extends \code{digest} by allowing one to
+The \code{getVDigest} function extends \code{digest} by allowing one to
 set a function that returns hash summaries as a character vector of the same length as the input. It also provides a performance advantage
 when repeated calls are necessary (e.g. applying a hash function repeatedly to an object). The returned function contains the same arguments as \code{digest} with the exception of the \code{raw} argument (see \code{\link{digest}} for more details).
 }
 \usage{
-set_vdigest(algo=c("md5", "sha1", "crc32", "sha256", "sha512", "xxhash32",
+getVDigest(algo=c("md5", "sha1", "crc32", "sha256", "sha512", "xxhash32",
             "xxhash64", "murmur32", "spookyhash"),
              errormode=c("stop","warn","silent"))
 }
@@ -22,24 +22,24 @@ set_vdigest(algo=c("md5", "sha1", "crc32", "sha256", "sha512", "xxhash32",
     \sQuote{silent} suppresses the error and returns an empty string.}
 }
 \value{
-  The \code{set_vdigest} function returns a function for a given
+  The \code{getVDigest} function returns a function for a given
   algorithm and error-mode.
 }
 \details{
  Note that since one hash summary will be returned for each element passed as input,  care must be taken when determining whether or not to include the data structure as  part of the object. For instance, to return the equivalent output of
  \code{digest(list("a"))} it would be necessary to wrap the list object itself
- \code{set_vdigest()(list(list("a")))}
+ \code{getVDigest()(list(list("a")))}
 }
 \seealso{\code{\link{digest}}, \code{\link{serialize}}, \code{\link{md5sum}}}
 \examples{
 stretch_key <- function(d, n) {
-    md5 <- set_vdigest()
+    md5 <- getVDigest()
     for (i in seq_len(n))
         d <- md5(d, serialize = FALSE)
     d
 }
 stretch_key('abc123', 65e3)
-sha1 <- set_vdigest(algo = 'sha1')
+sha1 <- getVDigest(algo = 'sha1')
 sha1(letters)
 
 md5Input <-
@@ -60,7 +60,7 @@ md5Output <-
       "d174ab98d277d9f5a5611c2c9f419d9f",
       "57edf4a22be3c955ac49da2e2107b67a")
 
-md5 <- set_vdigest()
+md5 <- getVDigest()
 stopifnot(identical(md5(md5Input, serialize = FALSE), md5Output))
 stopifnot(identical(digest(list("abc")),
                  md5(list(list("abc")))))
@@ -73,7 +73,7 @@ sha512Output <- c(
     "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
     "91ea1245f20d46ae9a037a989f54f1f790f0a47607eeb8a14d12890cea77a1bbc6c7ed9cf205e67b7f2b8fd4c7dfd3a7a8617e45f3c463d481c7e586c39ac1ed")
 
-sha512 <- set_vdigest(algo = 'sha512')
+sha512 <- getVDigest(algo = 'sha512')
 stopifnot(identical(sha512(sha512Input, serialize = FALSE), sha512Output))
 
 }

--- a/man/vdigest.Rd
+++ b/man/vdigest.Rd
@@ -1,0 +1,80 @@
+\name{set_vdigest}
+\alias{set_vdigest}
+\title{Set a vectorised function for creating hash function digests}
+\description{
+The \code{set_vdigest} function extends \code{digest} by allowing one to
+set a function that returns hash summaries as a character vector of the same length as the input. It also provides a performance advantage
+when repeated calls are necessary (e.g. applying a hash function repeatedly to an object). The returned function contains the same arguments as \code{digest} with the exception of the \code{raw} argument (see \code{\link{digest}} for more details).
+}
+\usage{
+set_vdigest(algo=c("md5", "sha1", "crc32", "sha256", "sha512", "xxhash32",
+            "xxhash64", "murmur32", "spookyhash"),
+             errormode=c("stop","warn","silent"))
+}
+\arguments{
+  \item{algo}{The algorithms to be used; currently available choices are
+    \code{md5}, which is also the default, \code{sha1}, \code{crc32},
+    \code{sha256}, \code{sha512}, \code{xxhash32}, \code{xxhash64},
+    \code{murmur32} and \code{spookyhash}.}
+  \item{errormode}{A character value denoting a choice for the behaviour in
+    the case of error: \sQuote{stop} aborts (and is the default value),
+    \sQuote{warn} emits a warning and returns \code{NULL} and
+    \sQuote{silent} suppresses the error and returns an empty string.}
+}
+\value{
+  The \code{set_vdigest} function returns a function for a given
+  algorithm and error-mode.
+}
+\details{
+ Note that since one hash summary will be returned for each element passed as input,  care must be taken when determining whether or not to include the data structure as  part of the object. For instance, to return the equivalent output of
+ \code{digest(list("a"))} it would be necessary to wrap the list object itself
+ \code{set_vdigest()(list(list("a")))}
+}
+\seealso{\code{\link{digest}}, \code{\link{serialize}}, \code{\link{md5sum}}}
+\examples{
+stretch_key <- function(d, n) {
+    md5 <- set_vdigest()
+    for (i in seq_len(n))
+        d <- md5(d, serialize = FALSE)
+    d
+}
+stretch_key('abc123', 65e3)
+sha1 <- set_vdigest(algo = 'sha1')
+sha1(letters)
+
+md5Input <-
+    c("",
+      "a",
+      "abc",
+      "message digest",
+      "abcdefghijklmnopqrstuvwxyz",
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+      paste("12345678901234567890123456789012345678901234567890123456789012",
+            "345678901234567890", sep=""))
+md5Output <-
+    c("d41d8cd98f00b204e9800998ecf8427e",
+      "0cc175b9c0f1b6a831c399e269772661",
+      "900150983cd24fb0d6963f7d28e17f72",
+      "f96b697d7cb7938d525a2f31aaf161d0",
+      "c3fcd3d76192e4007dfb496cca67e13b",
+      "d174ab98d277d9f5a5611c2c9f419d9f",
+      "57edf4a22be3c955ac49da2e2107b67a")
+
+md5 <- set_vdigest()
+stopifnot(identical(md5(md5Input, serialize = FALSE), md5Output))
+stopifnot(identical(digest(list("abc")),
+                 md5(list(list("abc")))))
+
+sha512Input <-c(
+    "",
+    "The quick brown fox jumps over the lazy dog."
+    )
+sha512Output <- c(
+    "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+    "91ea1245f20d46ae9a037a989f54f1f790f0a47607eeb8a14d12890cea77a1bbc6c7ed9cf205e67b7f2b8fd4c7dfd3a7a8617e45f3c463d481c7e586c39ac1ed")
+
+sha512 <- set_vdigest(algo = 'sha512')
+stopifnot(identical(sha512(sha512Input, serialize = FALSE), sha512Output))
+
+}
+\keyword{misc}

--- a/src/digest.c
+++ b/src/digest.c
@@ -459,3 +459,25 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
 
   return result;
 }
+
+
+SEXP vdigest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed){
+    R_xlen_t n = length(Txt);
+    if (TYPEOF(Txt) == RAWSXP || n == 0)
+        return(digest(Txt, Algo, Length, Skip, Leave_raw, Seed));
+    SEXP ans = PROTECT(allocVector(STRSXP, n));
+    SEXP d = R_NilValue;
+    if (TYPEOF(Txt) == VECSXP){
+        for (R_xlen_t i = 0; i < n; i++){
+            d = digest(VECTOR_ELT(Txt, i), Algo, Length, Skip, Leave_raw, Seed);
+            SET_STRING_ELT(ans, i, STRING_ELT(d, 0));
+        }
+    } else {
+        for (R_xlen_t i = 0; i < n; i++){
+            d = digest(STRING_ELT(Txt, i), Algo, Length, Skip, Leave_raw, Seed);
+            SET_STRING_ELT(ans, i, STRING_ELT(d, 0));
+        }
+    }
+    UNPROTECT(1);
+    return ans;
+}


### PR DESCRIPTION
This pr proposes a function `set_vdigest()` which allows for:

 - setting a vectorised version of `digest()` that is faster than simply using `base::Vectorize()` (this was raised in #2)
 - better performance for repeated calls

`set_vdigest()` returns a function for a given algo and errormode.

With regards to the second point, `set_vdigest()` has been structured such that the information that doesn't need to be repeated in each call is factored out (e.g. matching the algo via `match.arg()` each time)
 
A couple examples:
```r
stretch_key <- function(d, n) {
    md5 <- set_vdigest()
    for (i in seq_len(n))
        d <- md5(d, serialize = FALSE)
    d
}
stretch_key('abc123', 65e3)

sha1 <- set_vdigest(algo = 'sha1')
sha1(letters)
```

The output will always be a character vector so in this respect it differs from `digest` since the `raw` argument is not relevant in this case. I briefly considered whether to output a list if `raw == TRUE` but decided against this. Also I should note that there are some duplicated code blocks now with `digest`, although this has been reduced to some extent with the addition of a 'utils' file.

### benchmarks
```r

library(digest)

#vectorisation
md5 <- set_vdigest()
digest2 <- base::Vectorize(digest)
x <- rep(letters, 1e3)
rbenchmark::benchmark(
    a <- md5(x, serialize = FALSE),
    b <- digest2(x, serialize = FALSE),
    d <- vapply(x, digest, character(1), serialize = FALSE),
    replications = 5
)
all(a == b)
all(a == d)

#repeated calls
stretch_key <- function(d, n) {
    md5 <- set_vdigest()
    for (i in seq_len(n))
        d <- md5(d, serialize = FALSE)
    d
}

stretch_key2 <- function(d, n) {
    for (i in seq_len(n))
        d <- digest(d, serialize = FALSE)
    d
}
rbenchmark::benchmark(
    a <- stretch_key('abc123', 65e3),
    b <- stretch_key2('abc123', 65e3),
    replications = 10
)
a == b
```
