### PR TITLE
feat: implement CFB cipher mode

### DIFF
--- a/R/AES.R
+++ b/R/AES.R
@@ -1,13 +1,13 @@
 # This is loosely modelled on the AES code from the Python Crypto package.
 
-# Currently only ECB, CBC and CTR modes are supported...
+# Currently only ECB, CBC, CFB and CTR modes are supported...
 
 modes <- c("ECB", "CBC", "CFB", "PGP", "OFB", "CTR", "OPENPGP")
 
-AES <- function(key, mode=c("ECB", "CBC", "CTR"), IV=NULL) {
+AES <- function(key, mode=c("ECB", "CBC", "CFB", "CTR"), IV=NULL) {
     mode <- match(match.arg(mode), modes)
-    if (!(mode %in% c(1:2, 6)))
-        stop("Only ECB, CBC and CTR mode encryption are supported.")	# #nocov
+    if (!(mode %in% c(1:3, 6)))
+        stop("Only ECB, CBC, CFB and CTR mode encryption are supported.")	# #nocov
 
     key <- as.raw(key)
     IV <- as.raw(IV)
@@ -31,6 +31,24 @@ AES <- function(key, mode=c("ECB", "CBC", "CTR"), IV=NULL) {
                 ind <- (i-1)*16 + 1:16
                 IV <<- .Call(AESencryptECB, context, xor(text[ind], IV))
                 result[ind] <- IV
+            }
+            result
+        } else if (mode == 3) {
+            if (length(IV) != block_size) {
+                stop("IV length must equal block size")
+            }
+            result <- raw(length(text))
+            blocks <- split(text, ceiling(seq_along(text)/block_size))
+            i <- 0
+            for (b in blocks) {
+                if (block_size == length(IV)) {
+                    out <- .Call(AESencryptECB, context, IV)
+                }
+                len <- length(b)
+                ind <- i*length(IV)+1:len
+                i <- i + 1
+                result[ind] <- xor(b, out[0:len])
+                IV <<- result[ind]
             }
             result
         } else if (mode == 6) {
@@ -67,6 +85,24 @@ AES <- function(key, mode=c("ECB", "CBC", "CTR"), IV=NULL) {
                 result[ind] <- xor(res, IV)
                 IV <<- ciphertext[ind]
             }
+        } else if (mode == 3) {
+            if (length(IV) != block_size) {
+                stop("IV length must equal block size")
+            }
+            result <- raw(length(ciphertext))
+            blocks <- split(ciphertext, ceiling(seq_along(ciphertext)/block_size))
+            i <- 0
+            for (b in blocks) {
+                if (block_size == length(IV)) {
+                    out <- .Call(AESencryptECB, context, IV)
+                }
+                len <- length(b)
+                ind <- i*length(IV)+1:len
+                i <- i + 1
+                result[ind] <- xor(b, out[0:len])
+                IV <<- b
+            }
+
         } else if (mode == 6)
               result <- encrypt(ciphertext)
 

--- a/inst/tinytest/test_aes.R
+++ b/inst/tinytest/test_aes.R
@@ -80,3 +80,34 @@ ctr128 <- aes$encrypt(plaintext)
 expect_true(identical(ctr128, ctr128output))
 aes <- AES(key, mode="CTR", IV=iv)
 expect_true(identical(plaintext, aes$decrypt(ctr128, raw=TRUE)))
+
+#cfb 
+key <- hextextToRaw("2b7e151628aed2a6abf7158809cf4f3c")
+iv <- hextextToRaw("000102030405060708090a0b0c0d0e0f")
+#cfb not a multiplier of 16
+text <- "This is very secret string"
+key <- hextextToRaw("2b7e151628aed2a6abf7158809cf4f3c")
+iv <- hextextToRaw("000102030405060708090a0b0c0d0e0f")
+
+cfb128output <- hextextToRaw(paste("04960ebfb9044196ac6c4590bbdc8903",
+                                   "e1259a479e199af94518",sep=""))
+aes <- AES(key, mode="CFB", IV=iv)
+cfb128 <- aes$encrypt(text)
+expect_true(identical(cfb128, cfb128output))
+aes <- AES(key, mode="CFB", IV=iv)
+expect_true(identical(text, aes$decrypt(cfb128, raw=FALSE)))
+
+#cfb128
+cfb128output <- hextextToRaw(paste("3b3fd92eb72dad20333449f8e83cfb4a",
+                                   "c8a64537a0b3a93fcde3cdad9f1ce58b",
+                                   "26751f67a3cbb140b1808cf187a4f4df",
+                                   "c04b05357c5d1c0eeac4c66f9ff7f2e6",sep=""))
+aes <- AES(key, mode="CFB", IV=iv)
+cfb128 <- aes$encrypt(text)
+expect_true(identical(cfb128, cfb128output))
+aes <- AES(key, mode="CFB", IV=iv)
+expect_true(identical(text, aes$decrypt(cfb128, raw=TRUE)))
+
+
+
+

--- a/inst/tinytest/test_aes.R
+++ b/inst/tinytest/test_aes.R
@@ -108,6 +108,15 @@ expect_true(identical(cfb128, cfb128output))
 aes <- AES(key, mode="CFB", IV=iv)
 expect_true(identical(plaintext, aes$decrypt(cfb128, raw=TRUE)))
 
+# test throws exeception on IV null or not a multiplier of 16 bytes
+aes <- AES(key, mode="CFB", IV=NULL)
+expect_error(aes$encrypt(plaintext))
+expect_error(aes$decrypt(plaintext))
+
+aes <- AES(key, mode="CFB", IV=raw(15))
+expect_error(aes$encrypt(plaintext))
+expect_error(aes$decrypt(plaintext))
+
 
 
 

--- a/inst/tinytest/test_aes.R
+++ b/inst/tinytest/test_aes.R
@@ -103,10 +103,10 @@ cfb128output <- hextextToRaw(paste("3b3fd92eb72dad20333449f8e83cfb4a",
                                    "26751f67a3cbb140b1808cf187a4f4df",
                                    "c04b05357c5d1c0eeac4c66f9ff7f2e6",sep=""))
 aes <- AES(key, mode="CFB", IV=iv)
-cfb128 <- aes$encrypt(text)
+cfb128 <- aes$encrypt(plaintext)
 expect_true(identical(cfb128, cfb128output))
 aes <- AES(key, mode="CFB", IV=iv)
-expect_true(identical(text, aes$decrypt(cfb128, raw=TRUE)))
+expect_true(identical(plaintext, aes$decrypt(cfb128, raw=TRUE)))
 
 
 

--- a/man/AES.Rd
+++ b/man/AES.Rd
@@ -88,7 +88,7 @@ code
 aes <- AES(key, mode="CBC", iv)
 aes$decrypt(code, raw=TRUE)
 
-# For CFB mode: IV should be random initialized and must be the same length as the Block's block size
+# CFB mode: IV must be the same length as the Block's block size
 # Two different instances of AES are required for encryption and decryption
 iv <- sample(0:255, 16, replace=TRUE)
 aes <- AES(key, mode="CFB", iv)

--- a/man/AES.Rd
+++ b/man/AES.Rd
@@ -5,42 +5,42 @@
 Create AES block cipher object
 }
 \description{
-This creates an object that can perform the Advanced Encryption 
+This creates an object that can perform the Advanced Encryption
 Standard (AES) block cipher.
 }
 \usage{
-AES(key, mode=c("ECB", "CBC", "CTR"), IV=NULL)
+AES(key, mode=c("ECB", "CBC", "CFB", "CTR"), IV=NULL)
 }
 \arguments{
-  \item{key}{  
+  \item{key}{
 The key as a 16, 24 or 32 byte raw vector for AES-128, AES-192 or
 AES-256 respectively.
 }
-  \item{mode}{   
+  \item{mode}{
 The encryption mode to use.  Currently only \dQuote{electronic
-codebook} (ECB), \dQuote{cipher-block chaining} (CBC) and
+codebook} (ECB), \dQuote{cipher-block chaining} (CBC), \dQuote{cipher feedback} (CFB) and
 \dQuote{counter} (CTR) modes are supported.
 }
   \item{IV}{
-The initial vector for CBC mode or initial counter for CTR mode.
+The initial vector for CBC and CFB mode or initial counter for CTR mode.
 }
 }
 \value{
 An object of class \code{"AES"}.  This is a list containing the
-following component functions: 
+following component functions:
 
 \item{encrypt(text)}{A function to encrypt a text vector.  The text
 may be a single element character vector or a raw vector.  It returns
-the ciphertext as a raw vector.} 
+the ciphertext as a raw vector.}
 
 \item{decrypt(ciphertext, raw = FALSE)}{A function to decrypt the
 ciphertext. In ECB mode, the same AES
 object can be used for both encryption and decryption, but in
-CBC and CTR modes a new object needs to be
+CBC, CFB and CTR modes a new object needs to be
 created, using the same initial \code{key} and \code{IV} values.}
 
 \item{IV()}{Report on the current state of the initialization vector.
-As blocks are encrypted or decrypted in CBC or CTR mode, the initialization
+As blocks are encrypted or decrypted in CBC, CFB or CTR mode, the initialization
 vector is updated, so both operations can be performed sequentially on
 subsets of the text or ciphertext.}
 
@@ -50,9 +50,9 @@ the AES object.}
 }
 \details{
 The standard NIST definition of CTR mode doesn't define how the counter
-is updated, it just requires that it be updated with each block 
-and not repeat itself for a long time.  This implementation treats it as a 
-128 bit integer and adds 1 with each successive block.  
+is updated, it just requires that it be updated with each block
+and not repeat itself for a long time.  This implementation treats it as a
+128 bit integer and adds 1 with each successive block.
 }
 \author{
 The R interface was written by Duncan Murdoch. The design is loosely
@@ -61,8 +61,8 @@ implementation is by Christophe Devine.
 }
 \references{
 United States National Institute of Standards and Technology (2001).
-"Announcing the ADVANCED ENCRYPTION STANDARD (AES)". 
-Federal Information Processing Standards Publication 197.  
+"Announcing the ADVANCED ENCRYPTION STANDARD (AES)".
+Federal Information Processing Standards Publication 197.
 \url{https://csrc.nist.gov/publications/fips/fips197/fips-197.pdf}.
 
 Morris Dworkin (2001).
@@ -87,6 +87,17 @@ code
 # Need a new object for decryption in CBC mode
 aes <- AES(key, mode="CBC", iv)
 aes$decrypt(code, raw=TRUE)
+
+# For CFB mode: IV should be random initialized and must be the same length as the Block's block size
+# Two different instances of AES are required for encryption and decryption
+iv <- sample(0:255, 16, replace=TRUE)
+aes <- AES(key, mode="CFB", iv)
+code <- aes$encrypt(msg)
+code
+#decrypt
+aes <-  AES(key, mode="CFB", iv)
+aes$decrypt(code)
+
 
 # FIPS-197 examples
 
@@ -122,11 +133,11 @@ stopifnot(identical(plaintext, aes$decrypt(aes256, raw=TRUE)))
 # SP800-38a examples
 
 plaintext <- hextextToRaw(paste("6bc1bee22e409f96e93d7e117393172a",
-                                "ae2d8a571e03ac9c9eb76fac45af8e51", 
-                                "30c81c46a35ce411e5fbc1191a0a52ef", 
+                                "ae2d8a571e03ac9c9eb76fac45af8e51",
+                                "30c81c46a35ce411e5fbc1191a0a52ef",
                                 "f69f2445df4f9b17ad2b417be66c3710",sep=""))
 key <- hextextToRaw("2b7e151628aed2a6abf7158809cf4f3c")
-                                 
+
 ecb128output <- hextextToRaw(paste("3ad77bb40d7a3660a89ecaf32466ef97",
                                    "f5d3d58503b9699de785895a96fdbaaf",
                                    "43b1cd7f598ece23881b00e3ed030688",
@@ -146,7 +157,19 @@ cbc128 <- aes$encrypt(plaintext)
 stopifnot(identical(cbc128, cbc128output))
 aes <- AES(key, mode="CBC", IV=iv)
 stopifnot(identical(plaintext, aes$decrypt(cbc128, raw=TRUE)))
- 
+
+
+cfb128output <- hextextToRaw(paste("3b3fd92eb72dad20333449f8e83cfb4a",
+                                   "c8a64537a0b3a93fcde3cdad9f1ce58b",
+                                   "26751f67a3cbb140b1808cf187a4f4df",
+                                   "c04b05357c5d1c0eeac4c66f9ff7f2e6",sep=""))
+aes <- AES(key, mode="CFB", IV=iv)
+cfb128 <- aes$encrypt(plaintext)
+stopifnot(identical(cfb128, cfb128output))
+aes <- AES(key, mode="CFB", IV=iv)
+stopifnot(identical(plaintext, aes$decrypt(cfb128, raw=TRUE)))
+
+
 ctr128output <- hextextToRaw(paste("874d6191b620e3261bef6864990db6ce",
                                    "9806f66b7970fdff8617187bb9fffdff",
                                    "5ae4df3edbd5d35e5b4f09020db03eab",


### PR DESCRIPTION
Support [Cipher Feedback (CFB) mode](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Feedback_(CFB)) 

CFB uses a block cipher as a component of a random number generator. In CFB mode, the previous ciphertext block is encrypted and the output is XORed (see XOR) with the current plaintext block to create the current ciphertext block. The XOR operation conceals plaintext patterns. Plaintext cannot be directly worked on unless there is retrieval of blocks from either the beginning or end of the ciphertext.

fix: #118 