### PR TITLE
Support UTF-8 encoded file paths on Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
-2019-10-13  Bill Denney <wdenney@humanpredictions.com>
+2019-10-13  Jim Hester <james.f.hester@gmail.com>
+
 	* src/digest.c: Add support for UTF-8 file paths on Windows
+	* R/digest.R: Idem
 	* inst/tinytest/test_encoding.R: Add tests for UTF-8 file paths.
 
 2019-10-13  Bill Denney <wdenney@humanpredictions.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2019-10-13  Bill Denney <wdenney@humanpredictions.com>
+	* src/digest.c: Add support for UTF-8 file paths on Windows
+	* inst/tinytest/test_encoding.R: Add tests for UTF-8 file paths.
+
+2019-10-13  Bill Denney <wdenney@humanpredictions.com>
 
 	* R/sha1.R: Add sha1.formula()
 	* NAMESPACE: Idem

--- a/R/digest.R
+++ b/R/digest.R
@@ -90,7 +90,7 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
     algoint <- algo_int(algo)
     if (file) {
         algoint <- algoint+100
-        object <- path.expand(object)
+        object <- enc2utf8(path.expand(object))
         check_file(object, errormode)
     }
     ## if skip is auto (or any other text for that matter), we just turn it

--- a/inst/tinytest/test_encoding.R
+++ b/inst/tinytest/test_encoding.R
@@ -1,0 +1,17 @@
+d <- tempfile()
+dir.create(d)
+
+# A file path not representable in latin-1
+f <- file.path(d, "tricky-\u0151")
+
+# We need to use a binary mode connection so the newlines
+# are consistent across platforms
+con <- file(f, open = "wb")
+writeLines("foobar", con = con)
+close(con)
+
+expect_identical(digest::digest(file = f), "14758f1afd44c09b7992073ccf00b43d")
+
+expect_identical(digest::digest(f, file = TRUE), "14758f1afd44c09b7992073ccf00b43d")
+
+unlink(d, recursive = TRUE)


### PR DESCRIPTION
This assumes the file paths will be UTF-8 encoded, they most likely
will be with recent versions of R. The paths are converted to UTF-16 by
`MultiByteToWideChar()` before being passed to `_wfopen()`.

On other systems we call `fopen()` directly, as the code did before.

I also pulled out the individual calls to `fopen()` and put them above
the switch to reduce some repetition in the code.

There is a also a simple test which demonstrates the issue.

Fixes #89