### PR TITLE
Add sha1.( support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2019-11-03  Bill Denney <wdenney@predictions.com>
+
+	* R/sha1.R: Add support for the "(" class which is used in some formula
+	* NAMESPACE: Idem
+	* man/sha1.Rd: Idem; also corrected typo for old version behavior
+	* inst.tinytest/test_sha1.R: Add tests for the "(" class
+	* 
+
 2019-10-27  Thierry Onkelinx  <thierry.onkelinx@inbo.be>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -36,6 +36,7 @@ S3method(sha1, pairlist)
 S3method(sha1, POSIXct)
 S3method(sha1, POSIXlt)
 S3method(sha1, raw)
+S3method(sha1, "(")
 
 S3method(makeRaw, default)
 S3method(makeRaw, digest)

--- a/R/sha1.R
+++ b/R/sha1.R
@@ -449,3 +449,5 @@ sha1.formula <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
     )
     digest(y, algo = algo)
 }
+
+"sha1.(" <- sha1.formula

--- a/inst/tinytest/test_sha1.R
+++ b/inst/tinytest/test_sha1.R
@@ -17,6 +17,8 @@ x.dataframe.round$Y <- signif(x.dataframe.round$Y, 14)
 x.factor <- factor(letters)
 x.array.num <- as.array(x.numeric)
 x.formula <- a~b+c|d
+x.paren_formula <- a~(b+c)
+x.no_paren_formula <- a~b+c
 
 # tests using detailed numbers
 expect_false(identical(x.numeric, signif(x.numeric, 14)))
@@ -286,6 +288,9 @@ expect_true(
             digest(y, algo="sha1")
         }
     )
+)
+expect_true(
+    sha1(x.paren_formula) != sha1(x.no_paren_formula)
 )
 
 test.element <- list(

--- a/man/sha1.rd
+++ b/man/sha1.rd
@@ -22,6 +22,7 @@
 \alias{sha1.call}
 \alias{sha1.raw}
 \alias{sha1.formula}
+\alias{sha1.(}
 \title{Calculate a SHA1 hash of an object}
 \author{Thierry Onkelinx}
 \usage{
@@ -47,6 +48,7 @@ sha1(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
 \method{sha1}{call}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
 \method{sha1}{raw}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
 \method{sha1}{formula}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
+\method{sha1}{\(}(x, digits = 14, zapsmall = 7, ..., algo = "sha1")
 }
 \arguments{
 \item{x}{the object to calculate the SHA1}
@@ -90,5 +92,5 @@ with \code{sha1(x, algo = "sha1")}, they will be different starting from digest
 
 Until version 0.6.22, \code{sha1} ignored the attributes of the object for
 some classes. This was fixed in version 0.6.23. Use
-\code{option(sha1PackageVersion = 0.6.23)} to get the old behaviour.
+\code{option(sha1PackageVersion = 0.6.22)} to get the old behaviour.
 }


### PR DESCRIPTION
This fixes #128, but it has an issue with the documentation that appears to relate to the fact that the class name is "(".  I can't figure that one out with several tries for escaping it (nothing, quotes, and backslash all tried).