### PR TITLE
Speed up num2hex by removing some string operations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2019-11-11  Bill Denney <wdenney@humanpredictions.com>
+
+	* R/sha1.R: Increase efficiency of num2hex()
+
 2019-11-07  Bill Denney <wdenney@humanpredictions.com>
 
   * NAMESPACE: add sha1_digest() and sha1_attr_digest() Functions
@@ -85,7 +89,7 @@
 	* R/AES.R: Add support for CFB cipher mode
 	* man/AES.Rd: Add documentation
 	* inst/tinytest/test_aes.R: Add tests
-	
+
 2019-09-20  Matthew de Queljoe <matthew.dequeljoe@gmail.com>
 
 	* R/digest.R: refactor digest function

--- a/R/sha1.R
+++ b/R/sha1.R
@@ -398,30 +398,35 @@ num2hex <- function(x, digits = 14L, zapsmall = 7L){
     output <- rep(NA_character_, length(x))
     output[x.inf & x > 0] <- "Inf"
     output[x.inf & x < 0] <- "-Inf"
-    x.finite <- !x.na & !x.inf
-    x.hex <- sprintf("%a", x[x.finite])
-    exponent <- as.integer(gsub("^.*p", "", x.hex))
     # detect "small" numbers
-    zapsmall.hex <- floor(log2(10 ^ -zapsmall))
-    zero <- x.hex == sprintf("%a", 0) | exponent <= zapsmall.hex
-    if (any(zero)) {
-        output[x.finite][zero] <- "0"
-        if (all(zero)) {
-            return(output)
-        }
+    x.zero <- !x.na & !x.inf & abs(x) <= (2^floor(log2(10 ^ -zapsmall)))
+    if (any(x.zero)) {
+        output[x.zero] <- "0"
     }
+    x.finite <- !(x.na | x.inf | x.zero)
+    # The calculations for non-na, non-inf, non-zero values are computationally
+    # more intense.  Don't do them unless necessary.
+    if (!any(x.finite)) {
+        return(output)
+    }
+    x_abs <- abs(x[x.finite])
+    exponent <- floor(log2(x_abs))
+    negative <- c("", "-")[(x[x.finite] < 0) + 1]
+    x.hex <- sprintf("%a", x_abs*2^-exponent)
+    nc_x <- nchar(x.hex)
     digits.hex <- ceiling(log(10 ^ digits, base = 16))
-    mantissa <- x.hex[!zero] # select "large" numbers
-    # select mantissa
-    mantissa <- gsub(mantissa, pattern = ".*x1\\.{0,1}", replacement = "")
-    # select mantissa
-    mantissa <- gsub(mantissa, pattern = "p.*$", replacement = "")
-    mantissa <- substring(mantissa, 1, digits.hex) # select required precision
-    # remove potential trailing zero's
-    mantissa <- gsub(mantissa, pattern = "0*$", replacement = "")
-    negative <- ifelse(grepl(x.hex[!zero], pattern = "^-"), "-", "")
-    output[x.finite][!zero] <- paste0(negative, mantissa, " ", exponent[!zero])
+    # select mantissa (starting format is 0x1.[0-9a-f]+p[+-][0-9]+), remove the
+    # beginning through the decimal place, including the fact that exact powers
+    # of two will not have a decimal place.
+    mantissa <- x.hex
+    # Remove the beginning through the decimal place (if it exists).
+    mask_decimal <- startsWith(mantissa, "0x1.")
+    start_character <- 4 + mask_decimal
+    # select required precision
+    stop_character <- pmin(nc_x - 3, start_character + digits.hex - 1)
+    mantissa <- substring(x.hex, start_character, stop_character)
+    # Drop trailing zeros
+    mantissa <- gsub(x=mantissa, pattern="0*$", replacement="")
+    output[x.finite] <- sprintf("%s%s %d", negative, mantissa, exponent)
     return(output)
 }
-
-

--- a/R/sha1.R
+++ b/R/sha1.R
@@ -400,12 +400,10 @@ num2hex <- function(x, digits = 14L, zapsmall = 7L){
     output[x.inf & x < 0] <- "-Inf"
     # detect "small" numbers
     x.zero <- !x.na & !x.inf & abs(x) <= (2^floor(log2(10 ^ -zapsmall)))
-    if (any(x.zero)) {
-        output[x.zero] <- "0"
-    }
-    x.finite <- !(x.na | x.inf | x.zero)
+    output[x.zero] <- "0"
     # The calculations for non-na, non-inf, non-zero values are computationally
     # more intense.  Don't do them unless necessary.
+    x.finite <- !(x.na | x.inf | x.zero)
     if (!any(x.finite)) {
         return(output)
     }
@@ -418,9 +416,8 @@ num2hex <- function(x, digits = 14L, zapsmall = 7L){
     # select mantissa (starting format is 0x1.[0-9a-f]+p[+-][0-9]+), remove the
     # beginning through the decimal place, including the fact that exact powers
     # of two will not have a decimal place.
-    mantissa <- x.hex
     # Remove the beginning through the decimal place (if it exists).
-    mask_decimal <- startsWith(mantissa, "0x1.")
+    mask_decimal <- startsWith(x.hex, "0x1.")
     start_character <- 4 + mask_decimal
     # select required precision
     stop_character <- pmin(nc_x - 3, start_character + digits.hex - 1)


### PR DESCRIPTION
This is at least part of #133.

Results should be identical, and it should be ~40% faster:

```r
> microbenchmark::microbenchmark(
+   old_num2hex(x),
+   num2hex(x)
+ )
Unit: milliseconds
           expr      min       lq     mean   median       uq      max neval
 old_num2hex(x) 122.0020 138.5887 165.2797 154.6198 170.3841 297.2866   100
     num2hex(x)  77.0894  89.3238 103.2708  97.0571 113.1322 173.4948   100
```