### PR TITLE
Cache nosharing state of `base::serialize()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-12-05  Will Landau  <will.landau@gmail.com>
+
+	* R/init.R (.onLoad): Cache nosharing state in base::serialize
+	(.hasNoSharing): Return cached value
+	* R/digest.R (digest): Use cached value accessor
+	* R/vdigest.R (non_streaming_digest): Use cached value accessor
+
 2019-12-04  Dirk Eddelbuettel  <edd@debian.org>
 
 	* R/init.R (.onLoad): Cache isWindows state

--- a/R/digest.R
+++ b/R/digest.R
@@ -58,7 +58,7 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
     if (serialize && !file) {
         if(algo %in% non_streaming_algos){
             ## support the 'nosharing' option in pqR's base::serialize()
-            object <- if ("nosharing" %in% names(formals(base::serialize)))
+            object <- if (.hasNoSharing())
                 base::serialize (object, connection=NULL, ascii=ascii,
                                  nosharing=TRUE, version=serializeVersion)
             else

--- a/R/init.R
+++ b/R/init.R
@@ -30,6 +30,9 @@
                                                  packageVersion("digest"))
     ## cache if we are on Windows as the call is a little expensive (GH issue #137)
     .pkgenv[["isWindows"]] <- Sys.info()[["sysname"]] == "Windows"
+
+    ## cache if serialize() supports 'nosharing'
+    .pkgenv[["hasNoSharing"]] <- "nosharing" %in% names(formals(base::serialize))
 }
 
 .getSerializeVersion <- function() {
@@ -55,4 +58,9 @@
 .isWindows <- function() {
     ## return the cached value of Sys.info()[["sysname"]] == "Windows"
     .pkgenv[["isWindows"]]
+}
+
+.hasNoSharing <- function() {
+    ## return the cached value of "nosharing" %in% names(formals(base::serialize))
+    .pkgenv[["hasNoSharing"]]
 }

--- a/R/vdigest.R
+++ b/R/vdigest.R
@@ -51,7 +51,7 @@ non_streaming_digest <- function(algo, errormode, algoint){
 
         if (serialize && !file) {
             ## support the 'nosharing' option in pqR's base::serialize()
-            object <- if ("nosharing" %in% names(formals(base::serialize)))
+            object <- if (.hasNoSharing())
                 serialize_(
                     object,
                     connection = NULL,


### PR DESCRIPTION
Re https://github.com/eddelbuettel/digest/issues/140#issuecomment-562138505, this PR pre-computes the value of `"nosharing" %in% names(formals(base::serialize))` for use in `digest()` and `non_streaming_digest()`. Benchmarks from https://github.com/eddelbuettel/digest/issues/140#issuecomment-562413844 show a 12% speedup in `digest()` and a 25% speedup in functions from `getVDigest()` in repeated calls on small data.