### PR TITLE
fix invalid code in documentation

### DIFF
--- a/man/sha1.Rd
+++ b/man/sha1.Rd
@@ -107,5 +107,5 @@ with \code{sha1(x, algo = "sha1")}, they will be different starting from digest
 
 Until version 0.6.22, \code{sha1} ignored the attributes of the object for
 some classes. This was fixed in version 0.6.23. Use
-\code{option(sha1PackageVersion = 0.6.22)} to get the old behaviour.
+\code{options(sha1PackageVersion = "0.6.22")} to get the old behaviour.
 }


### PR DESCRIPTION
instead of "option" you likely wanted  "options"
and I think the version number needs quotes