### PR TITLE
bugfix: ignore the srcref attribute

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2019-12-12  Thierry Onkelinx <thierry.onkelinx@inbo.be>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+	* R/sha1.R: ignore the "srcref" attribute if set
+	* inst/tinytest/test_new_matrix_behaviour.R: update unit test
+	* inst/tinytest/test_sha1.R: update unit test
+	* man/sha1.Rd: update documentation
+
 2019-12-09  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version
@@ -126,7 +134,7 @@
         * R/AES.R: Add support for CFB cipher mode
         * man/AES.Rd: Add documentation
         * inst/tinytest/test_aes.R: Add tests
-	
+
 2019-09-20  Matthew de Queljoe <matthew.dequeljoe@gmail.com>
 
         * R/digest.R: refactor digest function

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Author: Dirk Eddelbuettel <edd@debian.org> with contributions
  Duncan Murdoch, Jim Hester, Wush Wu, Qiang Kou, Thierry Onkelinx, 
  Michel Lang, Viliam Simko, Kurt Hornik, Radford Neal, Kendon Bell,
  Matthew de Queljoe, Ion Suruceanu, and Bill Denney.
-Version: 0.6.23.1
+Version: 0.6.23.2
 Date: 2019-12-09
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Title: Create Compact Hash Digests of R Objects

--- a/R/sha1.R
+++ b/R/sha1.R
@@ -45,9 +45,7 @@ sha1.numeric <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
         digits = digits,
         zapsmall = zapsmall
     )
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
@@ -67,9 +65,7 @@ sha1.matrix <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
             ),
             ncol = ncol(x)
         )
-        if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-            attributes(y) <- attributes(x)
-        }
+        y <- add_attributes(x, y)
         attr(y, "digest::sha1") <- attr_sha1(
             x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
         )
@@ -85,9 +81,7 @@ sha1.matrix <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
 sha1.complex <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     # a vector of complex numbers is converted into 2-column matrix (Re,Im)
     y <- cbind(Re(x), Im(x))
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
@@ -96,9 +90,7 @@ sha1.complex <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
 
 sha1.Date <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     y <- as.numeric(x)
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
@@ -112,9 +104,7 @@ sha1.array <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
     y <- list(
         dimension = dim(x),
         value = as.numeric(x))
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
@@ -136,9 +126,7 @@ sha1.data.frame <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
     } else {
         y <- x
     }
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
@@ -160,9 +148,7 @@ sha1.list <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
     } else {
         y <- x
     }
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- list(
         class = class(x),
         digits = as.integer(digits),
@@ -178,9 +164,7 @@ sha1.POSIXlt <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
         lapply(unclass(as.POSIXlt(x)), unlist)
     )
     y$sec <- num2hex(y$sec, digits = digits, zapsmall = zapsmall)
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
@@ -195,9 +179,7 @@ sha1.POSIXct <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
         ...,
         algo = algo
     )
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
@@ -215,9 +197,7 @@ sha1.anova <- function(x, digits = 4L, zapsmall = 7L, ..., algo = "sha1"){
         digits = digits,
         zapsmall = zapsmall
     )
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
@@ -235,9 +215,7 @@ sha1.pairlist <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1") {
         algo = algo,
         FUN.VALUE = NA_character_
     )
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
@@ -271,9 +249,7 @@ sha1.function <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
         algo = algo,
         FUN.VALUE = NA_character_
     )
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = y, digits = digits, zapsmall = zapsmall, algo = algo, dots
     )
@@ -300,15 +276,25 @@ sha1.formula <- function(x, digits = 14L, zapsmall = 7L, ..., algo = "sha1"){
             digest(environment(x), algo = algo)
         )
     }
-    if (package_version("0.6.22.2") <= .getsha1PackageVersion()) {
-        attributes(y) <- c(attributes(y), "digest::attributes" = attributes(x))
-    }
+    y <- add_attributes(x, y)
     attr(y, "digest::sha1") <- attr_sha1(
         x = x, digits = digits, zapsmall = zapsmall, algo = algo, ...
     )
     digest(y, algo = algo)
 }
 "sha1.(" <- function(...) {sha1.formula(...)}
+
+add_attributes <- function(x, y) {
+    if (.getsha1PackageVersion() < package_version("0.6.22.2")) {
+        return(y)
+    }
+    extra <- attributes(x)
+    if (package_version("0.6.23.2") <= .getsha1PackageVersion()) {
+        extra <- extra[names(extra) != "srcref"]
+    }
+    attributes(y) <- c(attributes(y), "digest::attributes" = extra)
+    return(y)
+}
 
 # sha1_attr_digest variants ####
 
@@ -423,7 +409,7 @@ num2hex <- function(x, digits = 14L, zapsmall = 7L){
     stop_character <- pmin(nc_x - 3, start_character + digits.hex - 1)
     mantissa <- substring(x.hex, start_character, stop_character)
     # Drop trailing zeros
-    mantissa <- gsub(x=mantissa, pattern="0*$", replacement="")
+    mantissa <- gsub(x = mantissa, pattern = "0*$", replacement = "")
     output[x.finite] <- sprintf("%s%s %d", negative, mantissa, exponent)
     return(output)
 }

--- a/inst/tinytest/test_new_matrix_behaviour.R
+++ b/inst/tinytest/test_new_matrix_behaviour.R
@@ -42,6 +42,7 @@ expect_true(
                 apply(x.matrix.num, 2, digest:::num2hex),
                 ncol = ncol(x.matrix.num)
             )
+            z <- digest:::add_attributes(x.matrix.num, z)
             attr(z, "digest::sha1") <- list(
                 class = "matrix",
                 digits = 14L,

--- a/inst/tinytest/test_sha1.R
+++ b/inst/tinytest/test_sha1.R
@@ -475,14 +475,22 @@ for (algo in c("md5", "sha1", "crc32", "sha256", "sha512", "xxhash32",
 expect_true(is.character(sha1(sessionInfo())))
 
 # check the effect of attributes from version 0.6.22.2
+options(sha1PackageVersion = utils::packageVersion("digest"))
 check_attribute_effect <- function(x) {
     y <- x
     attr(y, "test") <- "junk"
     expect_false(sha1(x) == sha1(y))
 }
-options(sha1PackageVersion = utils::packageVersion("digest"))
 test.element <- list(2 + 5i, x.array.num, Sys.Date(), Sys.time(), y ~ x)
 test.element <- c(test.element, list(x.dataframe), anova.list, function(x){x})
 for (z in test.element) {
     check_attribute_effect(z)
 }
+
+# check that sha1() on contributed functions maintain there hash after storing
+f <- tempfile(fileext = ".rds")
+x <- digest::sha1
+saveRDS(x, f)
+y <- readRDS(f)
+expect_identical(sha1(x), sha1(y))
+expect_identical(sha1(x, environment = FALSE), sha1(y, environment = FALSE))

--- a/man/sha1.Rd
+++ b/man/sha1.Rd
@@ -108,4 +108,6 @@ with \code{sha1(x, algo = "sha1")}, they will be different starting from digest
 Until version 0.6.22, \code{sha1} ignored the attributes of the object for
 some classes. This was fixed in version 0.6.23. Use
 \code{options(sha1PackageVersion = "0.6.22")} to get the old behaviour.
+
+Version 0.6.24 and later ignore attributes named \code{srcref}.
 }


### PR DESCRIPTION
For some reason, the `srcref` attribute changes when you store and read a function from a non-recommended package. Below is a repex using the latest CRAN version of digest.

```
f <- tempfile(fileext = ".rds")
x <- digest::sha1
saveRDS(x, f)
y <- readRDS(f)
options(sha1PackageVersion = NULL)
sha1(x) != sha1(y)
sha1(x, environment = FALSE) != sha1(y, environment = FALSE)
options(sha1PackageVersion = "0.6.22")
sha1(x) == sha1(y)
sha1(x, environment = FALSE) == sha1(y, environment = FALSE)
```