### PR TITLE
add back fun=NULL

### DIFF
--- a/R/digest.R
+++ b/R/digest.R
@@ -108,7 +108,7 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
                      as.integer(seed))
     } else if (algo == "spookyhash"){
         # 0s are the seeds. They are included to enable testing against fastdigest.
-        val <- paste(.Call(spookydigest_impl, object, skip, 0, 0, serializeVersion), collapse="")
+        val <- paste(.Call(spookydigest_impl, object, skip, 0, 0, serializeVersion, NULL), collapse="")
     }
 
     ## crc32 output was not guaranteed to be eight chars long, which we corrected


### PR DESCRIPTION
Solves #146. Was a dumb mistake in the end where there is a `fun` argument to `spookydigest_impl` which doesn't get put in.

```r
> temp_library_location <- tempfile(pattern="lib")
> dir.create(temp_library_location)
> .libPaths(temp_library_location)
> install.packages("https://github.com/kendonB/digest/archive/ecb34bc.tar.gz", type = "source", repos = NULL, quiet = TRUE)
trying URL 'https://github.com/kendonB/digest/archive/ecb34bc.tar.gz'
downloaded 126 KB

> example(setRefClass, echo = FALSE) # use this to generate 'xx' instance of reference class.
Call:
$undo()


Undoes the last edit() operation
        and update the edits field accordingly.
        

Reference class 'mEdit' [package ".GlobalEnv"] with 2 fields
 $ data : num [1:4, 1:3] 1 2 3 4 5 6 7 8 9 10 ...
 $ edits: list()
 and 17 methods, of which 3 are  possibly relevant:
   edit, show#envRefClass, undo
> # Works
> digest::digest(xx, algo = "spookyhash")
[1] "d4fbf9c7699d4303503d108c5722d7af"
```
