### PR TITLE
Cleanly sidestep file.access issue, to add reliability without adding deps

### DIFF
--- a/R/digest.R
+++ b/R/digest.R
@@ -167,7 +167,9 @@ check_file <- function(object, errormode){
         return(.errorhandler("The specified pathname is not a file: ",
                              object, mode=errormode))
     }
-    if (file.access(object, 4)) {
+    read_test <- NULL
+    try(read_test <- file(object, "rb"))
+    if(typeof(read_test) != "integer"){
         return(.errorhandler("The specified file is not readable: ",
                              object, mode=errormode))                  			# #nocov end
     }


### PR DESCRIPTION
Hi Dirk,
Attempt at cleanly sidestepping (not fixing) file.access issue,  https://github.com/eddelbuettel/digest/issues/49
without creating any dependencies,
and without masking a problem that's within R.

Hoping to align with the spirit of your extensive work on the Rcpp and inline packages, by perhaps getting a little closer to the horse's mouth:

by using an R call that's slightly more direct or reliable:
file()

Wanting to develop things like Rcpp shows great care, attention to detail and perseverance, so I thought a change to a lower-level function that's more stable across platforms, might be of interest

This PR attached to illustrate. Even if you like the idea -- you're likely to be able to express it better or more concisely than I am! Thanks for considering the idea
cheers,