### PR TITLE
Speed enhancements

### DIFF
--- a/R/digest.R
+++ b/R/digest.R
@@ -36,8 +36,12 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
                    errormode=c("stop","warn","silent"),
                    serializeVersion=.getSerializeVersion()) {
 
-    algo <- match.arg(algo)
-    errormode <- match.arg(errormode)
+    # Explicitly specify choices; this is much faster than having match.arg()
+    # infer them from the function's formals.
+    algo <- match.arg(algo, c("md5", "sha1", "crc32", "sha256", "sha512",
+                              "xxhash32", "xxhash64", "murmur32",
+                              "spookyhash", "blake3"))
+    errormode <- match.arg(errormode, c("stop", "warn", "silent"))
 
     if (is.infinite(length)) {
         length <- -1               # internally we use -1 for infinite len

--- a/R/digest.R
+++ b/R/digest.R
@@ -58,12 +58,12 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
 
     if (serialize && !file) {
         if(algo %in% non_streaming_algos){
-            ## support the 'nosharing' option in pqR's base::serialize()
+            ## support the 'nosharing' option in pqR's serialize()
             object <- if (.hasNoSharing())
-                base::serialize (object, connection=NULL, ascii=ascii,
+                serialize (object, connection=NULL, ascii=ascii,
                                  nosharing=TRUE, version=serializeVersion)
             else
-                base::serialize (object, connection=NULL, ascii=ascii,
+                serialize (object, connection=NULL, ascii=ascii,
                                  version=serializeVersion)
         }
         ## we support raw vectors, so no mangling of 'object' is necessary

--- a/R/digest.R
+++ b/R/digest.R
@@ -52,16 +52,15 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
         file <- TRUE                  	# nocov
     }
 
-    streaming_algos <- c("spookyhash")
-    non_streaming_algos <- c("md5", "sha1", "crc32", "sha256", "sha512",
-                             "xxhash32", "xxhash64", "murmur32", "blake3")
-    if(algo %in% streaming_algos && !serialize){
+    is_streaming_algo <- algo == "spookyhash"
+
+    if (is_streaming_algo && !serialize) {
         .errorhandler(paste0(algo, " algorithm is not available without serialization."),  # #nocov
                       mode=errormode)                                                      # #nocov
     }
 
     if (serialize && !file) {
-        if(algo %in% non_streaming_algos){
+        if (!is_streaming_algo) {
             ## support the 'nosharing' option in pqR's serialize()
             object <- if (.hasNoSharing())
                 serialize (object, connection=NULL, ascii=ascii,
@@ -77,7 +76,7 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
             skip <- set_skip(object, ascii)
 
     } else if (!is.character(object) && !inherits(object,"raw") &&
-               algo %in% non_streaming_algos) {
+               !is_streaming_algo) {
         return(.errorhandler(paste("Argument object must be of type character",		    # #nocov
                                    "or raw vector if serialize is FALSE"), mode=errormode)) # #nocov
     }
@@ -85,7 +84,7 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
         return(.errorhandler("file=TRUE can only be used with a character object",          # #nocov
                              mode=errormode))                                               # #nocov
 
-    if (file && algo %in% streaming_algos)
+    if (file && is_streaming_algo)
         return(.errorhandler(paste0(algo, " algorithm can not be used with files."),        # #nocov
                              mode=errormode))                                               # #nocov
 
@@ -103,7 +102,7 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
     ## into 0 because auto should have been converted into a number earlier
     ## if it was valid [SU]
     if (is.character(skip)) skip <- 0
-    if (algo %in% non_streaming_algos) {
+    if (!is_streaming_algo) {
         val <- .Call(digest_impl,
                      object,
                      as.integer(algoint),

--- a/R/digest.R
+++ b/R/digest.R
@@ -72,7 +72,7 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
         ## we support raw vectors, so no mangling of 'object' is necessary
         ## regardless of R version
         ## skip="auto" - skips the serialization header [SU]
-        if (any(!is.na(pmatch(skip,"auto"))))
+        if (is.character(skip) && skip == "auto")
             skip <- set_skip(object, ascii)
 
     } else if (!is.character(object) && !inherits(object,"raw") &&

--- a/R/init.R
+++ b/R/init.R
@@ -32,7 +32,7 @@
     .pkgenv[["isWindows"]] <- Sys.info()[["sysname"]] == "Windows"
 
     ## cache if serialize() supports 'nosharing'
-    .pkgenv[["hasNoSharing"]] <- "nosharing" %in% names(formals(base::serialize))
+    .pkgenv[["hasNoSharing"]] <- "nosharing" %in% names(formals(serialize))
 }
 
 .getSerializeVersion <- function() {
@@ -61,6 +61,6 @@
 }
 
 .hasNoSharing <- function() {
-    ## return the cached value of "nosharing" %in% names(formals(base::serialize))
+    ## return the cached value of "nosharing" %in% names(formals(serialize))
     .pkgenv[["hasNoSharing"]]
 }

--- a/R/vdigest.R
+++ b/R/vdigest.R
@@ -21,8 +21,9 @@
 getVDigest <- function(algo = c("md5", "sha1", "crc32", "sha256", "sha512",
                                  "xxhash32", "xxhash64", "murmur32", "spookyhash"),
                         errormode=c("stop","warn","silent")){
-    algo <- match.arg(algo)
-    errormode <- match.arg(errormode)
+    algo <- match.arg(algo, c("md5", "sha1", "crc32", "sha256", "sha512",
+                              "xxhash32", "xxhash64", "murmur32", "spookyhash"))
+    errormode <- match.arg(errormode, c("stop","warn","silent"))
     algoint <- algo_int(algo)
     non_streaming_algos <- c("md5", "sha1", "crc32", "sha256", "sha512",
                              "xxhash32", "xxhash64", "murmur32")

--- a/R/vdigest.R
+++ b/R/vdigest.R
@@ -50,7 +50,7 @@ non_streaming_digest <- function(algo, errormode, algoint){
         }
 
         if (serialize && !file) {
-            ## support the 'nosharing' option in pqR's base::serialize()
+            ## support the 'nosharing' option in pqR's serialize()
             object <- if (.hasNoSharing())
                 serialize_(
                     object,
@@ -170,6 +170,6 @@ streaming_digest <- function(algo, errormode, algoint){
 
 serialize_ <- function(object, ...){
     if (length(object))
-        return(lapply(object, base::serialize, ...))
-    base::serialize(object, ...)
+        return(lapply(object, serialize, ...))
+    serialize(object, ...)
 }

--- a/inst/tinytest/test_digest.R
+++ b/inst/tinytest/test_digest.R
@@ -297,3 +297,20 @@ expect_identical(getVDigest('spookyhash')(list(iris)),
 #expect_true(
 #  grepl("spookyhash algorithm is not available without serialization.", error.message)
 #)
+
+
+## Ensure that all values of algo are actually allowed (in case a new one is
+## added in the future). The call to match.arg() passes choices explicitly
+## because it is significantly faster to do it than to have it automatically
+## infer the possible choices from the function's formals.
+
+# Grab the possible values of algo, then call digest() for each one.
+algos <- eval(formals(digest)$algo)
+for (algo in algos) {
+  digest(123, algo = algo)
+}
+# Same for getVDigest
+algos <- eval(formals(getVDigest)$algo)
+for (algo in algos) {
+  getVDigest(algo = algo)
+}


### PR DESCRIPTION
Closes #163.

The changes:

* Replaced `base::serialize` with `serialize`.
* Pass explicit choices to `match.arg()`.
* Only check if an algorithm is streaming one time.
* Faster check for `skip=="auto"`. The previous code for that used `any(!is.na(pmatch(skip,"auto")))`. That was added a long time ago, in 543df6705591e1eea585e829a2f0ba26fedff1ea, and it seems unnecessarily complicated. The new version checks for an exact match; the previous version allowed partial matches, like if `skip` was `"au"`, but that doesn't seem like desirable behavior to me.

There's still a little room for improvement by having a replacement for `match.arg`, but I decided against it after I tried it out and found that the benefits were marginal.


Simple benchmark results:

```R
library(digest)
microbenchmark::microbenchmark(
  digest(123, algo = "sha512"),
  times = 10000
)

## Before
#> Unit: microseconds
#>                          expr    min      lq    mean median     uq     max neval
#>  digest(123, algo = "sha512") 34.839 43.5675 46.8873 45.373 47.695 136.589  1000

## After
#> Unit: microseconds
#>                          expr    min      lq     mean median     uq     max neval
#>  digest(123, algo = "sha512") 19.817 20.5795 22.08357 21.029 21.849 108.512  1000
```

And some profiles:

Before (590ms): https://rpubs.com/wch/671614
After (280ms): https://rpubs.com/wch/671745


Interestingly, in the After condition, serialization took 30% of the total time and the actual hashing took about 18% of the total time.