### PR TITLE
digest.Rd: minor documentation updates

### DIFF
--- a/man/digest.Rd
+++ b/man/digest.Rd
@@ -2,7 +2,7 @@
 \alias{digest}
 \title{Create hash function digests for arbitrary R objects}
 \description{
-  The \code{digest} function applies a cryptographical hash function to
+  The \code{digest} function applies a hash function to
   arbitrary R objects. By default, the objects are internally
   serialized, and either one of the currently implemented MD5 and SHA-1
   hash functions algorithms can be used to compute a compact digest of

--- a/man/digest.Rd
+++ b/man/digest.Rd
@@ -1,9 +1,9 @@
 \name{digest}
 \alias{digest}
-\title{Create hash function digests for arbitrary R objects}
+\title{Create hash function digests for arbitrary R objects or files}
 \description{
   The \code{digest} function applies a hash function to
-  arbitrary R objects. By default, the objects are internally
+  arbitrary R objects or files. By default, the objects are internally
   serialized, and either one of the currently implemented MD5 and SHA-1
   hash functions algorithms can be used to compute a compact digest of
   the serialized object.


### PR DESCRIPTION
Some suggestions:

- xxhash and others are non-cryptographic hash functions, so better not refer to cryptographic functions only (in the description)
- I suggest to advertise more explicitly that `digest` can also be used to generate file hashes.