### PR TITLE
Fix Windows encoding issues

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-09-22  András Svraka  <svraka.andras@gmail.com>
+
+	* R/vdigest.R (non_streaming_digest): Ensure UTF-8 encoded file paths on Windows
+	* inst/tinytest/test_encoding.R: Expand test coverage for path name encodings on Windows
+
 2021-03-28  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docs/mkdmt-src/: Moved mkdocs-material input

--- a/R/vdigest.R
+++ b/R/vdigest.R
@@ -82,6 +82,7 @@ non_streaming_digest <- function(algo, errormode, algoint){
         if (file) {
             algoint <- algoint+100
             object <- path.expand(object)
+            if (.isWindows()) object <- enc2utf8(object)
             check_file(object, errormode)
         }
         ## if skip is auto (or any other text for that matter), we just turn it

--- a/inst/tinytest/test_encoding.R
+++ b/inst/tinytest/test_encoding.R
@@ -6,7 +6,7 @@ d <- tempfile()
 dir.create(d)
 
 # A file path not representable in latin-1
-f <- file.path(d, "tricky-\u0151")
+f <- file.path(d, "tricky-ő")
 
 # We need to use a binary mode connection so the newlines
 # are consistent across platforms
@@ -17,5 +17,11 @@ close(con)
 expect_identical(digest::digest(file = f), "14758f1afd44c09b7992073ccf00b43d")
 
 expect_identical(digest::digest(f, file = TRUE), "14758f1afd44c09b7992073ccf00b43d")
+
+vd <- getVDigest()
+
+expect_identical(vd(file = f), "14758f1afd44c09b7992073ccf00b43d")
+
+expect_identical(vd(f, file = TRUE), "14758f1afd44c09b7992073ccf00b43d")
 
 unlink(d, recursive = TRUE)


### PR DESCRIPTION
This PR fixes #171.

Regarding the questions that came up:

> [W]e should be able to test this on Windows too, right?

Tested locally on Windows with non-English locale. I don't have access to other Windows machines.

``` r
sessionInfo()
#> R version 4.1.1 (2021-08-10)
#> Platform: x86_64-w64-mingw32/x64 (64-bit)
#> Running under: Windows 10 x64 (build 18363)
#> 
#> Matrix products: default
#> 
#> locale:
#> [1] LC_COLLATE=Hungarian_Hungary.1250  LC_CTYPE=Hungarian_Hungary.1250   
#> [3] LC_MONETARY=Hungarian_Hungary.1250 LC_NUMERIC=C                      
#> [5] LC_TIME=Hungarian_Hungary.1250    
```

> Do you want to add the line as a PR but also makes sure it (with the change) passes a unit test (which it would fail without) ?

Unit test changes are in a single commit, let me know if you want to split it.

> And, while you're at it do me a favour and add an entry to ChangeLog ? I am old school and use those, I can add it otherwise. (Emacs makes that easy, others make it more work.)

Done. (I'm using Emacs but apparently `vc-update-change-log` doesn't support Git?)