### PR TITLE
AES: add `padding` argument to allow CBC mode to use padding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-06-25  Dean Attali  <daattali@gmail.com>
+
+        * R/AES.R: Add `padding` parameter to `AES()` to allow CBC mode to use PKCS#7 padding
+
 2023-04-30  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,10 @@
 2023-06-25  Dean Attali  <daattali@gmail.com>
 
-        * R/AES.R: Add `padding` parameter to `AES()` to allow CBC mode to use PKCS#7 padding
-
-        * man/AES.Rd: Document the `raw` argument of `AES()$decrypt()`
+        * R/AES.R: Add `padding` parameter to `AES()` to allow CBC mode to use
+        PKCS#7 padding
+        * inst/tinytest/test_aes.R: Add tests for new `padding` parameter
+        * man/AES.Rd: Document the `raw` argument of `AES()$decrypt()` and the
+        new `padding` parameter
 
 2023-04-30  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@
 
         * R/AES.R: Add `padding` parameter to `AES()` to allow CBC mode to use PKCS#7 padding
 
+        * man/AES.Rd: Document the `raw` argument of `AES()$decrypt()`
+
 2023-04-30  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/man/AES.Rd
+++ b/man/AES.Rd
@@ -9,7 +9,7 @@ This creates an object that can perform the Advanced Encryption
 Standard (AES) block cipher.
 }
 \usage{
-AES(key, mode=c("ECB", "CBC", "CFB", "CTR"), IV=NULL)
+AES(key, mode=c("ECB", "CBC", "CFB", "CTR"), IV=NULL, padding=FALSE)
 }
 \arguments{
   \item{key}{
@@ -23,6 +23,9 @@ codebook} (ECB), \dQuote{cipher-block chaining} (CBC), \dQuote{cipher feedback} 
 }
   \item{IV}{
 The initial vector for CBC and CFB mode or initial counter for CTR mode.
+}
+  \item{padding}{
+Whether or not PKCS#7 padding is used during encryption and decryption in CBC mode.
 }
 }
 \value{
@@ -86,6 +89,10 @@ code
 # Need a new object for decryption in CBC mode
 aes <- AES(key, mode="CBC", iv)
 aes$decrypt(code, raw=TRUE)
+
+# In CBC mode, the input length must be a multiple of 16 bytes.
+# You can use `padding = TRUE` to ensure the input length is always valid.
+AES(key, mode="CBC", iv, padding = TRUE)$encrypt(as.raw(1:15))
 
 # CFB mode: IV must be the same length as the Block's block size
 # Two different instances of AES are required for encryption and decryption

--- a/man/AES.Rd
+++ b/man/AES.Rd
@@ -40,7 +40,8 @@ the ciphertext as a raw vector.}
 ciphertext. In ECB mode, the same AES
 object can be used for both encryption and decryption, but in
 CBC, CFB and CTR modes a new object needs to be
-created, using the same initial \code{key} and \code{IV} values.}
+created, using the same initial \code{key} and \code{IV} values.
+Returns a single element character vector, or a raw vector if \code{raw = TRUE}.}
 
 \item{IV()}{Report on the current state of the initialization vector.
 As blocks are encrypted or decrypted in CBC, CFB or CTR mode, the initialization


### PR DESCRIPTION
Soon after writing my last comment in https://github.com/eddelbuettel/digest/issues/185 I realized why my tests were not working. Every other tool I used to encrypt/decrypt using CBC mode is assuming that padding is used. 

Once I implemented padding, digest::AES returned exactly the same as expected

**NOTE:** I did not add an entry in the changelog, did not update the version in DESCRIPTION, and did not update the documentation site files