### PR TITLE
Use endian macros to set endianness

### DIFF
--- a/src/crc32c/crc32c_config.h
+++ b/src/crc32c/crc32c_config.h
@@ -6,7 +6,11 @@
 #define CRC32C_CRC32C_CONFIG_H_
 
 // Define to 1 if building for a big-endian platform.
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define BYTE_ORDER_BIG_ENDIAN 1
+#else
 #define BYTE_ORDER_BIG_ENDIAN 0
+#endif
 
 // Define to 1 if the compiler has the __builtin_prefetch intrinsic.
 #define HAVE_BUILTIN_PREFETCH 1


### PR DESCRIPTION
@eddelbuettel Could you please see if this works for you?

These macros should be supported both by GCC and Clang. And if undefined, should use default 0.