### PR TITLE
Add version dependency for tinytest

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2023-08-03  Michael Chirico  <chiricom@google.com>
 
-        * DESCRIPTION (Suggests): Add version dependency on 'tinytest' for
-        `expect_length()`
+        * tests/tinytest.R: Define `expect_length()` if needed (it's only
+        available from tinytest 1.4.1, Feb. 2023)
 
 2023-06-28  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-08-03  Michael Chirico  <chiricom@google.com>
+        * DESCRIPTION (Suggests): Add version dependency on 'tinytest' for
+        `expect_length()`
+
 2023-06-28  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.6.33

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 2023-08-03  Michael Chirico  <chiricom@google.com>
+
         * DESCRIPTION (Suggests): Add version dependency on 'tinytest' for
         `expect_length()`
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,5 @@ BugReports: https://github.com/eddelbuettel/digest/issues
 Depends: R (>= 3.3.0)
 Imports: utils
 License: GPL (>= 2)
-Suggests: tinytest, simplermarkdown
+Suggests: tinytest (>= 1.4.1), simplermarkdown
 VignetteBuilder: simplermarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,5 @@ BugReports: https://github.com/eddelbuettel/digest/issues
 Depends: R (>= 3.3.0)
 Imports: utils
 License: GPL (>= 2)
-Suggests: tinytest (>= 1.4.1), simplermarkdown
+Suggests: tinytest, simplermarkdown
 VignetteBuilder: simplermarkdown

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -12,7 +12,7 @@ if (requireNamespace("tinytest", quietly=TRUE)) {
     if (packageVersion("tinytest") >= "0.9.3") {
         ## expect_length is in tinytest 1.4.1
         if (!"expect_length" %in% getNamespaceExports("tinytest")) {
-            expect_length <- function(x, n) stopifnot(length(x) == n)
+            expect_length <- function(x, n) expect_equal(length(x), n)
         }
         tinytest::test_package("digest")
     }

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -10,6 +10,10 @@ if (requireNamespace("tinytest", quietly=TRUE)) {
 
     ## we need version 0.9.3 or later
     if (packageVersion("tinytest") >= "0.9.3") {
+        ## expect_length is in tinytest 1.4.1
+        if (!"expect_length" %in% getNamespaceExports("tinytest")) {
+            expect_length <- function(x, n) stopifnot(length(x) == n)
+        }
         tinytest::test_package("digest")
     }
 }

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -12,7 +12,7 @@ if (requireNamespace("tinytest", quietly=TRUE)) {
     if (packageVersion("tinytest") >= "0.9.3") {
         ## expect_length is in tinytest 1.4.1
         if (!"expect_length" %in% getNamespaceExports("tinytest")) {
-            expect_length <- function(x, n) expect_equal(length(x), n)
+            expect_length <- function(x, n) tinytest::expect_equal(length(x), n)
         }
         tinytest::test_package("digest")
     }


### PR DESCRIPTION
This is required for `expect_length()`, per the NEWS:

https://github.com/markvanderloo/tinytest/blob/eafa51d509747829273351b8ca61b84c76030124/pkg/NEWS#L13-L14

Given 1.4.1 is less than 6 months old, we might also add a workaround to avoid such a recent package version. Happy to make that change.