### PR TITLE
Missing include for uint32_t

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-08-03  Michael Chirico  <chiricom@google.com>
+
+        * src/digest.c: `#include <stdint.h>` for `uint32_t`
+
 2023-06-28  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.6.33

--- a/src/digest.c
+++ b/src/digest.c
@@ -21,6 +21,7 @@
 
 */
 
+#include <stdint.h> // for uint32_t
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Same provenance as https://github.com/RcppCore/Rcpp/pull/1272.