### PR TITLE
blake3: backport upstream patch for Big-endian platforms

### DIFF
--- a/src/blake3.c
+++ b/src/blake3.c
@@ -89,7 +89,7 @@ INLINE void output_chaining_value(const output_t *self, uint8_t cv[32]) {
   memcpy(cv_words, self->input_cv, 32);
   blake3_compress_in_place(cv_words, self->block, self->block_len,
                            self->counter, self->flags);
-  memcpy(cv, cv_words, 32);
+  store_cv_words(cv, cv_words);
 }
 
 INLINE void output_root_bytes(const output_t *self, uint64_t seek, uint8_t *out,

--- a/src/blake3_impl.h
+++ b/src/blake3_impl.h
@@ -154,6 +154,25 @@ INLINE void load_key_words(const uint8_t key[BLAKE3_KEY_LEN],
   key_words[7] = load32(&key[7 * 4]);
 }
 
+INLINE void store32(void *dst, uint32_t w) {
+  uint8_t *p = (uint8_t *)dst;
+  p[0] = (uint8_t)(w >> 0);
+  p[1] = (uint8_t)(w >> 8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+}
+
+INLINE void store_cv_words(uint8_t bytes_out[32], uint32_t cv_words[8]) {
+  store32(&bytes_out[0 * 4], cv_words[0]);
+  store32(&bytes_out[1 * 4], cv_words[1]);
+  store32(&bytes_out[2 * 4], cv_words[2]);
+  store32(&bytes_out[3 * 4], cv_words[3]);
+  store32(&bytes_out[4 * 4], cv_words[4]);
+  store32(&bytes_out[5 * 4], cv_words[5]);
+  store32(&bytes_out[6 * 4], cv_words[6]);
+  store32(&bytes_out[7 * 4], cv_words[7]);
+}
+
 void blake3_compress_in_place(uint32_t cv[8],
                               const uint8_t block[BLAKE3_BLOCK_LEN],
                               uint8_t block_len, uint64_t counter,

--- a/src/blake3_portable.c
+++ b/src/blake3_portable.c
@@ -9,14 +9,6 @@
 #include "blake3_impl.h"
 #include <string.h>
 
-INLINE void store32(void *dst, uint32_t w) {
-  uint8_t *p = (uint8_t *)dst;
-  p[0] = (uint8_t)(w >> 0);
-  p[1] = (uint8_t)(w >> 8);
-  p[2] = (uint8_t)(w >> 16);
-  p[3] = (uint8_t)(w >> 24);
-}
-
 INLINE uint32_t rotr32(uint32_t w, uint32_t c) {
   return (w >> c) | (w << (32 - c));
 }
@@ -155,7 +147,7 @@ INLINE void hash_one_portable(const uint8_t *input, size_t blocks,
     blocks -= 1;
     block_flags = flags;
   }
-  memcpy(out, cv, 32);
+  store_cv_words(out, cv);
 }
 
 void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,


### PR DESCRIPTION
See: https://github.com/BLAKE3-team/BLAKE3/commit/0b13637ae31c2e7e1a471e39258606fabb01685e

@eddelbuettel This fixes `blake3` for Big endian.


As for spooky hash, perhaps it is either to be disabled or left as is: it works on Big-endian, but computes different values, so it will fail comparisons against pre-computed Little-endian values.
See: https://github.com/facebook/folly/blob/4c603f8c2add8d0228de0e073c5ae3ce9b02b6f3/folly/hash/SpookyHashV2.h#L35-L36
Also:
> The hash would run, and it would produce equally good results, but they'd be different results from little-endian platforms.
http://burtleburtle.net/bob/hash/spooky.html