### PR TITLE
expand hashing algorithms that support `raw = TRUE` option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-08-19 Carl A. B. Pearson <carl.ab.pearson@gmail.com>
+
+        * src/digest.c: enable all hashing algorithms to return raw output.
+        * inst/tinytest/test_raw.R: test raw vs not consistency for all algos.
+
 2024-08-15  Kevin Ushey  <kevinushey@gmail.com>
 
 	* src/raes.c: Calloc => R_Calloc; Free => R_Free

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2024-08-19 Carl A. B. Pearson <carl.ab.pearson@gmail.com>
+2024-08-19  Carl A. B. Pearson  <carl.ab.pearson@gmail.com>
 
   * src/digest.c: enable all hashing algorithms to return raw output.
   * inst/tinytest/test_raw.R: test raw vs not consistency for all algos.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd
              person("Michael", "Chirico", role="ctb", comment = c(ORCID = "0000-0003-0787-087X")),
              person("Kevin", "Ushey", role="ctb"),
              person("Carl", "Pearson", role="ctb", comment = c(ORCID = "0000-0003-0701-7860")))
-Version: 0.6.38
+Version: 0.6.37.1
 Date: 2024-08-19
 Title: Create Compact Hash Digests of R Objects
 Description: Implementation of a function 'digest()' for the creation of hash

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,8 +39,9 @@ Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd
              person("Winston", "Chang", role="ctb", comment = c(ORCID = "0000-0002-1576-2126")),
              person("Dean", "Attali", role="ctb", comment = c(ORCID = "0000-0002-5645-3493")),
              person("Michael", "Chirico", role="ctb", comment = c(ORCID = "0000-0003-0787-087X")),
-             person("Kevin", "Ushey", role="ctb"))
-Version: 0.6.37
+             person("Kevin", "Ushey", role="ctb"),
+             person("Carl", "Pearson", role="ctb", comment = c(ORCID = "0000-0003-0701-7860")))
+Version: 0.6.38
 Date: 2024-08-19
 Title: Create Compact Hash Digests of R Objects
 Description: Implementation of a function 'digest()' for the creation of hash

--- a/inst/tinytest/test_raw.R
+++ b/inst/tinytest/test_raw.R
@@ -18,3 +18,15 @@ expect_equal(current, expected)
 
 ## feed raw to sha1() to test sha1.raw() as well
 expect_true(sha1(expected) == "75a2995eeec0fcb5d7fa97c676a37f4e224981a1")
+
+for (algo in c("md5", "sha1", "crc32", "sha256", "sha512",
+               "xxhash32", "xxhash64", "murmur32",
+               "spookyhash", "blake3", "crc32c",
+               "xxh3_64", "xxh3_128")) {
+  digestchar <- digest("The quick brown fox", algo = algo, raw = FALSE)
+  digestraw <- paste0(as.character(
+    digest("The quick brown fox", algo = algo, raw = TRUE)
+  ), collapse = "")
+  
+  expect_equal(digestchar, digestraw, info = sprintf("error in %s", algo))
+}

--- a/inst/tinytest/test_raw.R
+++ b/inst/tinytest/test_raw.R
@@ -19,14 +19,16 @@ expect_equal(current, expected)
 ## feed raw to sha1() to test sha1.raw() as well
 expect_true(sha1(expected) == "75a2995eeec0fcb5d7fa97c676a37f4e224981a1")
 
+
 for (algo in c("md5", "sha1", "crc32", "sha256", "sha512",
                "xxhash32", "xxhash64", "murmur32",
                "spookyhash", "blake3", "crc32c",
                "xxh3_64", "xxh3_128")) {
-  digestchar <- digest("The quick brown fox", algo = algo, raw = FALSE)
-  digestraw <- paste0(as.character(
-    digest("The quick brown fox", algo = algo, raw = TRUE)
-  ), collapse = "")
-  
-  expect_equal(digestchar, digestraw, info = sprintf("error in %s", algo))
+
+    digestchar <- digest("The quick brown fox", algo = algo, raw = FALSE)
+    digestraw <- paste0(as.character(
+        digest("The quick brown fox", algo = algo, raw = TRUE)
+    ), collapse = "")
+
+    expect_equal(digestchar, digestraw, info = sprintf("error in %s", algo))
 }

--- a/src/digest.c
+++ b/src/digest.c
@@ -137,7 +137,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
     FILE *fp=0;
     char *txt;
     int algo = INTEGER_VALUE(Algo);
-    int  length = INTEGER_VALUE(Length);
+    int length = INTEGER_VALUE(Length);
     int skip = INTEGER_VALUE(Skip);
     int seed = INTEGER_VALUE(Seed);
     int leaveRaw = INTEGER_VALUE(Leave_raw);
@@ -305,7 +305,6 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         break;
     }
     case 101: {     /* md5 file case */
-        int j;
         md5_context ctx;
         output_length = 16;
         unsigned char buf[BUF_SIZE];
@@ -330,7 +329,6 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         break;
     }
     case 102: {     /* sha1 file case */
-        int j;
         sha1_context ctx;
         output_length = 20;
         unsigned char buf[BUF_SIZE];
@@ -374,7 +372,6 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         break;
     }
     case 104: {     /* sha256 file case */
-        int j;
         sha256_context ctx;
         output_length = 32;
         unsigned char buf[BUF_SIZE];
@@ -398,7 +395,6 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         break;
     }
     case 105: {     /* sha2-512 file case */
-        int j;
         SHA512_CTX ctx;
         output_length = SHA512_DIGEST_LENGTH;
         uint8_t sha512sum[output_length], *d = sha512sum;

--- a/src/digest.c
+++ b/src/digest.c
@@ -120,12 +120,12 @@ void rev_memcpy(char *dst, const void *src, int len) {
     }
 }
 
-#define dump32(WHAT) decl_tmp32(WHAT);            \
+#define _dump32(WHAT) decl_tmp32(WHAT);            \
 if (leaveRaw) {                                   \
     rev_memcpy(output, &tmp, output_length);      \
 } else snprintf(output, 128, "%08x", tmp);
 
-#define dump64(WHAT) decl_tmp64(WHAT);            \
+#define _dump64(WHAT) decl_tmp64(WHAT);            \
 if (leaveRaw) {                                   \
     rev_memcpy(output, &tmp, output_length);      \
 } else snprintf(output, 128, "%016" PRIx64, tmp);
@@ -208,7 +208,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         val  = digest_crc32(0L, 0, 0);
         val  = digest_crc32(val, (unsigned char*) txt, l);
 
-        dump32(val);
+        _dump32(val);
         break;
     }
     case 4: {     /* sha256 case */
@@ -251,7 +251,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
 
         XXH32_hash_t val = XXH32(txt, nChar, seed);
 
-        dump32(val);
+        _dump32(val);
         break;
     }
     case 7: {     /* xxhash64 case */
@@ -259,7 +259,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
 
         XXH64_hash_t val = XXH64(txt, nChar, seed);
         
-        dump64(val);
+        _dump64(val);
         break;
     }
     case 8: {     /* MurmurHash3 32 */
@@ -267,7 +267,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
 
         unsigned int val = PMurHash32(seed, txt, nChar);
 
-        dump32(val);
+        _dump32(val);
         break;
     }
     case 10: {     /* blake3 */
@@ -288,7 +288,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         uint32_t crc = 0;       /* initial value, can be zero */
         crc = crc32c_extend(crc, (const uint8_t*) txt, (size_t) nChar);
 
-        dump32(crc);
+        _dump32(crc);
         break;
     }
     case 12: {		/* xxh3_64bits */
@@ -296,7 +296,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
 
         XXH64_hash_t val = XXH3_64bits_withSeed(txt, nChar, seed);
 
-        dump64(val);
+        _dump64(val);
         break;
     }
     case 13: {		/* xxh3_128bits */
@@ -378,7 +378,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
                 val  = digest_crc32(val , buf, (unsigned) nChar);
         }
 
-        dump32(val);
+        _dump32(val);
         break;
     }
     case 104: {     /* sha256 file case */
@@ -468,7 +468,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         XXH32_hash_t val =  XXH32_digest(state);
         XXH32_freeState(state);
 
-        dump32(val);
+        _dump32(val);
         break;
     }
     case 107: {     /* xxhash64 */
@@ -501,7 +501,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         XXH64_hash_t val =  XXH64_digest(state);
         XXH64_freeState(state);
         
-        dump64(val);
+        _dump64(val);
         break;
     }
     case 108: {     /* murmur32 */
@@ -527,7 +527,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         }
         unsigned int val = PMurHash32_Result(h1, carry, total_length);
 
-        dump32(val);
+        _dump32(val);
         break;
     }
     case 110: {     /* blake3 file case */
@@ -570,7 +570,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
                 crc = crc32c_extend(crc, (const uint8_t*) buf, (size_t) nChar);
         }
 
-        dump32(crc);
+        _dump32(crc);
         break;
     }
     case 112: {     /* xxh3_64 */
@@ -603,7 +603,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         XXH64_hash_t val =  XXH3_64bits_digest(state);
         XXH3_freeState(state);
 
-        dump64(val);
+        _dump64(val);
         break;
     }
     case 113: {     /* xxh3_128 */


### PR DESCRIPTION
I would like to use `digest` in some other work, but can't at the moment because the hashing algorithm I'd like to use doesn't support returning raw results.

I've worked up some changes to expand support for `raw = TRUE` for all the algorithms. I've added a test to confirm this is working.