### PR TITLE
draft approach to exporting hash methods directly

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,10 @@
 ## package has a dynamic library
-useDynLib(digest, digest_impl=digest, vdigest_impl=vdigest, digest2int_impl=digest2int, AESinit, AESencryptECB, AESdecryptECB, spookydigest_impl, is_little_endian, is_big_endian, .registration=TRUE)
+useDynLib(digest,
+          digest_impl=digest, vdigest_impl=vdigest, digest2int_impl=digest2int,
+          AESinit, AESencryptECB, AESdecryptECB, spookydigest_impl,
+          is_little_endian, is_big_endian,
+          md5_impl=direct_MD5, sha1_impl=direct_SHA1,
+          .registration=TRUE)
 
 importFrom(utils, packageVersion)
 
@@ -12,9 +17,14 @@ export(AES,
        sha1_attr_digest,
        sha1_digest,
        hmac,
-       makeRaw)
+       makeRaw,
+       md5)
 
 S3method(print, AES)
+
+S3method(md5, default)
+S3method(md5, integer)
+S3method(md5, raw)
 
 S3method(sha1, anova)
 S3method(sha1, array)

--- a/R/md5.R
+++ b/R/md5.R
@@ -1,0 +1,12 @@
+
+md5 <- function(x, leaveRaw = TRUE, ...) {
+  UseMethod("md5")
+}
+
+md5.default <- function(x, leaveRaw, ...) {
+  digest(x, algo = "md5", ...)
+}
+
+md5.raw <- function(x, leaveRaw) .Call(md5_impl, x, leaveRaw)
+
+md5.integer <- function(x, leaveRaw) .Call(md5_impl, x, leaveRaw)

--- a/inst/tinytest/test_directs.R
+++ b/inst/tinytest/test_directs.R
@@ -1,0 +1,22 @@
+
+## tests for raw output
+
+suppressMessages(library(digest))
+
+for (algo in c("md5")) {
+               #"sha1", "crc32", "sha256", "sha512", "xxhash32", "xxhash64", "murmur32",
+               # "spookyhash", "blake3", "crc32c",
+               #"xxh3_64", "xxh3_128")) {
+
+    tarfun <- get(algo)
+    raw_jenny <- as.raw(as.integer(c(8, 6, 7, 5, 3, 0, 9)))
+    # integers are 8 bytes; raws are 2 hexes = 1 bytes
+    ext_jenny <- c()
+    for (i in seq_along(raw_jenny)) {
+      ext_jenny <- c(ext_jenny, c(raw_jenny[i], raw(7)))
+    }
+    tarfun(ext_jenny, leaveRaw = TRUE)
+    tarfun(as.integer(c(8, 6, 7, 5, 3, 0, 9)), leaveRaw = TRUE)
+    digest(raw_jenny, algo = "md5", serialize = FALSE, raw = TRUE)
+    
+}

--- a/src/digest.h
+++ b/src/digest.h
@@ -1,0 +1,90 @@
+/*
+
+  digest -- hash digest functions for R
+
+  Copyright (C) 2003 - 2024  Dirk Eddelbuettel <edd@debian.org>
+
+  This file is part of digest.
+
+  digest is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  digest is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with digest.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include <stdint.h> // for uint32_t
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <R.h>
+#include <Rdefines.h>
+#include <Rinternals.h>
+#include <Rversion.h>
+#include <inttypes.h>
+
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
+// Also already used in sha2.h
+//
+// We can rely on WORDS_BIGENDIAN only be defined on big endian systems thanks to Rconfig.
+//
+// A number of other #define based tests are in other source files here for different hash
+// algorithm implementations notably crc32c, pmurhash, sha2 and xxhash
+//
+// A small and elegant test is also in package qs based on https://stackoverflow.com/a/1001373
+
+// edd 02 Dec 2013  use Rconfig.h to define BYTE_ORDER, unless already defined
+#ifndef BYTE_ORDER
+// see sha2.c comments, and on the internet at large
+#define LITTLE_ENDIAN 1234
+#define BIG_ENDIAN    4321
+#ifdef WORDS_BIGENDIAN
+#define BYTE_ORDER  BIG_ENDIAN
+#else
+#define BYTE_ORDER  LITTLE_ENDIAN
+#endif
+#endif
+
+SEXP is_big_endian(void);
+SEXP is_little_endian(void);
+
+#if defined(R_VERSION) && R_VERSION >= R_Version(3,0,0)
+#define RVLENGTH(ROBJ) XLENGTH(ROBJ)
+#else
+#define RVLENGTH(ROBJ) LENGTH(ROBJ)
+#endif
+
+#ifndef USESHA512
+#define USESHA512 0
+#endif
+
+#if USESHA512
+static const char *sha2_hex_digits = "0123456789abcdef";
+#endif
+
+// direct_ALGO
+// @param ALGO which algorithm 
+//
+// creates a function taking arguments:
+// @param inputtype: the type of the input, must be one of the enumerated types
+// @param input: the input to hash
+// @param leaveRaw: whether to return the hash as a raw vector or a character string
+#define direct_ALGO_SIG(ALGO) SEXP direct_ ## ALGO\
+(const SEXP input, const SEXP leaveRaw)
+
+direct_ALGO_SIG(SHA1);
+direct_ALGO_SIG(MD5);
+
+SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);
+SEXP vdigest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);

--- a/src/init.c
+++ b/src/init.c
@@ -24,9 +24,15 @@
 #include <R_ext/Rdynload.h>
 #include "xxhash.h"
 #include "pmurhash.h"
+#include "digest.h"
+
+#define stringify(TAR) #TAR
+#define Register_ALGO(ALGO) R_RegisterCCallable("digest", stringify(direct_ ## ALGO), (DL_FUNC) &direct_ ## ALGO);
 
 void R_init_digest(DllInfo *info) {
     R_RegisterCCallable("digest", "PMurHash32", (DL_FUNC) &PMurHash32);
+    Register_ALGO(SHA1);
+    Register_ALGO(MD5);
 
     /* tools::package_native_routine_registration_skeleton() reports empty set */
     R_registerRoutines(info,


### PR DESCRIPTION
This is a rough in idea for how `{digest}` might approach exposing access to the available hashing methods. The rough idea is:

 - want to make the methods directly available, with minimal overhead (which means the user accepting more of the burden of doing checks)
 - ... also for more basic R types directly
 - ... in a way that's easy to maintain / extend
 - ... and that can be incorporated in a backwards compatible way that eliminates code duplication

Marking this as draft, as the idea is to get a feel for the acceptability of this kind of approach before investing a fair chunk of refactor effort.