### PR TITLE
refactor to split header off digest

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-09-19  Carl A. B. Pearson  <carl.ab.pearson@gmail.com>
+
+	* src/digest.h: introduced, to enable additional registrations in init.c
+        * src/digest.c: add digest.h, prune other imports, eliminate version check
+	* src/init.c: introduce digest.h in anticipation of new registrations
+
 2024-08-28  Carl A. B. Pearson  <carl.ab.pearson@gmail.com>
 
 	* R/digest.R (digest): parse errormode only if in error conditions

--- a/src/digest.c
+++ b/src/digest.c
@@ -25,10 +25,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <R.h>
+
 #include <Rdefines.h>
 #include <Rinternals.h>
-#include <Rversion.h>
+
+#include "digest.h"
+
 #include <inttypes.h>
 #include "sha1.h"
 #include "sha2.h"
@@ -172,11 +174,7 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
     int output_length = -1;
     if (IS_RAW(Txt)) { /* Txt is either RAW */
         txt = (unsigned char*) RAW(Txt);
-#if defined(R_VERSION) && R_VERSION >= R_Version(3,0,0)
         nChar = XLENGTH(Txt);
-#else
-        nChar = LENGTH(Txt);
-#endif
     } else { /* or a string */
         txt = (unsigned char*) STRING_VALUE(Txt);
         nChar = strlen((char *)txt);

--- a/src/digest.h
+++ b/src/digest.h
@@ -1,0 +1,30 @@
+/*
+
+  digest -- hash digest functions for R
+
+  Copyright (C) 2003 - 2024  Dirk Eddelbuettel <edd@debian.org>
+
+  This file is part of digest.
+
+  digest is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  digest is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with digest.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include <Rinternals.h>
+
+SEXP is_big_endian(void);
+SEXP is_little_endian(void);
+
+SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);
+SEXP vdigest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);

--- a/src/init.c
+++ b/src/init.c
@@ -24,6 +24,7 @@
 #include <R_ext/Rdynload.h>
 #include "xxhash.h"
 #include "pmurhash.h"
+#include "digest.h"
 
 void R_init_digest(DllInfo *info) {
     R_RegisterCCallable("digest", "PMurHash32", (DL_FUNC) &PMurHash32);


### PR DESCRIPTION
Per the title, splits out header. Also cleans up imports and eliminates the version dependency check (already enforced via DESCRIPTION).