### PR TITLE
encapsulate and expose core hashing algorithms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,8 @@ Description: Implementation of a function 'digest()' for the creation of hash
 URL: https://github.com/eddelbuettel/digest, https://dirk.eddelbuettel.com/code/digest.html
 BugReports: https://github.com/eddelbuettel/digest/issues
 Depends: R (>= 3.3.0)
-Imports: utils
+LinkingTo: RApiSerialize
+Imports: utils, RApiSerialize
 License: GPL (>= 2)
 Suggests: tinytest, simplermarkdown, microbenchmark
 VignetteBuilder: simplermarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,6 @@ BugReports: https://github.com/eddelbuettel/digest/issues
 Depends: R (>= 3.3.0)
 Imports: utils
 License: GPL (>= 2)
-Suggests: tinytest, simplermarkdown
+Suggests: tinytest, simplermarkdown, microbenchmark
 VignetteBuilder: simplermarkdown
 Encoding: UTF-8

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,9 +3,11 @@ useDynLib(digest, digest_impl=digest, vdigest_impl=vdigest,
           digest2int_impl=digest2int, AESinit, AESencryptECB, AESdecryptECB,
           spookydigest_impl, is_little_endian, is_big_endian,
           xxh32_impl=direct_XXH32, md5_impl=direct_MD5,
+          serialize_to_raw, unserialize_from_raw,
           .registration=TRUE)
 
 importFrom(utils, packageVersion)
+import(RApiSerialize)
 
 ## and exported functions
 export(AES,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,9 @@
 ## package has a dynamic library
-useDynLib(digest, digest_impl=digest, vdigest_impl=vdigest, digest2int_impl=digest2int, AESinit, AESencryptECB, AESdecryptECB, spookydigest_impl, is_little_endian, is_big_endian, .registration=TRUE)
+useDynLib(digest, digest_impl=digest, vdigest_impl=vdigest,
+          digest2int_impl=digest2int, AESinit, AESencryptECB, AESdecryptECB,
+          spookydigest_impl, is_little_endian, is_big_endian,
+          xxh32_impl=direct_XXH32, md5_impl=direct_MD5,
+          .registration=TRUE)
 
 importFrom(utils, packageVersion)
 
@@ -12,7 +16,18 @@ export(AES,
        sha1_attr_digest,
        sha1_digest,
        hmac,
-       makeRaw)
+       makeRaw,
+       md5, xxh32)
+
+S3method(md5, default)
+S3method(md5, raw)
+S3method(md5, integer)
+S3method(md5, numeric)
+
+S3method(xxh32, default)
+S3method(xxh32, raw)
+S3method(xxh32, integer)
+S3method(xxh32, numeric)
 
 S3method(print, AES)
 

--- a/R/md5.R
+++ b/R/md5.R
@@ -1,0 +1,14 @@
+
+md5 <- function(x, raw = TRUE, seed = 0L, ...) {
+  UseMethod("md5")
+}
+
+md5.default <- function(x, raw = TRUE, seed = 0L, ...) {
+  digest(x, algo = "md5", raw = raw, seed = seed, ...)
+}
+
+md5.raw <- function(x, raw = TRUE, seed = 0L, ...) .Call(md5_impl, x, raw, seed)
+
+md5.integer <- function(x, raw = TRUE, seed = 0L, ...) .Call(md5_impl, x, raw, seed)
+
+md5.numeric <- function(x, raw = TRUE, seed = 0L, ...) .Call(md5_impl, x, raw, seed)

--- a/R/xxh32.R
+++ b/R/xxh32.R
@@ -1,0 +1,13 @@
+xxh32 <- function(x, raw = TRUE, seed = 0L, ...) {
+  UseMethod("xxh32")
+}
+
+xxh32.default <- function(x, raw = TRUE, seed = 0L, ...) {
+  digest(x, algo = "xxhash32", raw = raw, seed = seed, ...)
+}
+
+xxh32.raw <- function(x, raw = TRUE, seed = 0L, ...) .Call(xxh32_impl, x, raw, seed)
+
+xxh32.integer <- function(x, raw = TRUE, seed = 0L, ...) .Call(xxh32_impl, x, raw, seed)
+
+xxh32.numeric <- function(x, raw = TRUE, seed = 0L, ...) .Call(xxh32_impl, x, raw, seed)

--- a/inst/tinytest/test_direct.R
+++ b/inst/tinytest/test_direct.R
@@ -1,0 +1,14 @@
+
+## tests for raw output
+
+suppressMessages(library(digest))
+
+for (algo in c("md5", "xxhash32")) {
+    jennys <- as.raw(as.integer(c(8,6,7,5,3,0,9)))
+    direct <- list(md5 = md5, xxhash32 = xxh32)[[algo]]
+    print(microbenchmark::microbenchmark(
+      digest = digest(jennys, serialize = FALSE, raw = TRUE, algo = algo),
+      direct = direct(jennys),
+      check = "equal", times = 1e3
+    ))
+}

--- a/man/direct.Rd
+++ b/man/direct.Rd
@@ -1,0 +1,47 @@
+\docType{methods}
+\name{direct}
+
+\alias{md5}
+\alias{md5.default}
+\alias{md5.integer}
+\alias{md5.numeric}
+\alias{md5.raw}
+
+\alias{xxh32}
+\alias{xxh32.default}
+\alias{xxh32.integer}
+\alias{xxh32.numeric}
+\alias{xxh32.raw}
+
+\title{Apply hashing algorithms directly}
+\author{Carl A. B. Pearson}
+\usage{
+md5(x, raw = TRUE, ...)
+\method{md5}{default}(x, raw = TRUE, ...)
+\method{md5}{integer}(x, raw = TRUE, ...)
+\method{md5}{numeric}(x, raw = TRUE, ...)
+\method{md5}{raw}(x, raw = TRUE, ...)
+
+xxh32(x, raw = TRUE, ...)
+\method{xxh32}{default}(x, raw = TRUE, ...)
+\method{xxh32}{integer}(x, raw = TRUE, ...)
+\method{xxh32}{numeric}(x, raw = TRUE, ...)
+\method{xxh32}{raw}(x, raw = TRUE, ...)
+
+}
+\arguments{
+\item{x}{the object to hash}
+
+\item{raw}{a logical scalar; whether to return a raw (TRUE, the default) or a
+character string.}
+
+\item{...}{other arguments passed to \code{\link{digest}}; only used if the
+direct method does not provide the generic for \code{x} argument.}
+}
+\description{
+Calculate the hash of a simple object. The main difference with
+\code{digest(x, algo = ...)} is that these direct methods can more quickly
+hash simpler objects, because there are fewer checks on the input. When your
+code can otherwise guarantee the inputs are fine, and those inputs are simpler
+objects, these methods can help with performance.
+}

--- a/src/digest.h
+++ b/src/digest.h
@@ -32,4 +32,7 @@ SEXP is_little_endian(void);
 SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);
 SEXP vdigest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);
 
+SEXP direct_XXH32(const SEXP input, const SEXP Leave_raw, const int seed);
+SEXP direct_MD5(const SEXP input, const SEXP Leave_raw, const int seed);
+
 #endif // DIGEST_H

--- a/src/digest.h
+++ b/src/digest.h
@@ -21,6 +21,9 @@
 
 */
 
+#ifndef DIGEST_H
+#define DIGEST_H
+
 #include <Rinternals.h>
 
 SEXP is_big_endian(void);
@@ -28,3 +31,5 @@ SEXP is_little_endian(void);
 
 SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);
 SEXP vdigest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);
+
+#endif // DIGEST_H

--- a/src/digest.h
+++ b/src/digest.h
@@ -32,7 +32,7 @@ SEXP is_little_endian(void);
 SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);
 SEXP vdigest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed);
 
-SEXP direct_XXH32(const SEXP input, const SEXP Leave_raw, const int seed);
-SEXP direct_MD5(const SEXP input, const SEXP Leave_raw, const int seed);
+SEXP direct_XXH32(const SEXP input, const SEXP Leave_raw, const SEXP seed);
+SEXP direct_MD5(const SEXP input, const SEXP Leave_raw, const SEXP seed);
 
 #endif // DIGEST_H

--- a/src/init.c
+++ b/src/init.c
@@ -28,6 +28,8 @@
 
 void R_init_digest(DllInfo *info) {
     R_RegisterCCallable("digest", "PMurHash32", (DL_FUNC) &PMurHash32);
+    R_RegisterCCallable("digest", "direct_MD5", (DL_FUNC) &direct_MD5);
+    R_RegisterCCallable("digest", "direct_XXH32", (DL_FUNC) &direct_XXH32);
 
     /* tools::package_native_routine_registration_skeleton() reports empty set */
     R_registerRoutines(info,

--- a/src/serializing.cpp
+++ b/src/serializing.cpp
@@ -1,0 +1,14 @@
+
+#include <RApiSerializeAPI.h>   	// provides C API with serialization for R
+
+extern "C" {
+
+SEXP serialize_to_raw(SEXP inp) {
+    return serializeToRaw(inp, Rf_ScalarInteger(2), Rf_ScalarLogical(1));
+}
+
+SEXP unserialize_from_raw(SEXP inp) {
+    return unserializeFromRaw(inp);
+}
+
+}


### PR DESCRIPTION
This draft shows the notional extraction of the core hashing capability in prep for exposing the algorithms directly.

Whatever the precise implementation approach, to me it seems inevitable that the right approach is to pop each algorithm out of digest, and turn digest into a traffic manager (and in the next layer of this notional series of PRs: provide a direct approach to linking with the algorithms more directly).

This implements that pop-out via a macro to regularize the interface. In essense, that macro is forming a base class, with each macro invocation on the collected bits for each algorithm effectively declaring the subclasses. We could approach this style of solution via some of the C approaches to introducing a class system, but I think the macro approach is the cleanest. If we absolutely wanted a non-preprocessing version, then switching to C++ seems like the preferred approach.

If we're roughly comfortable with the macro approach, the remaining steps for this PR:
 - [ ] write core_XYZ for all of the algorithms
 - [ ] substitute those into digest, prune any vestigal code
 - [ ] write changelog

Optionally: introduce a stream_ALGO complementary to core_ALGO (and maybe rename core_ALGO to one_ALGO?). This would further consolidate digest / DRY out algorithm implementation