### PR TITLE
Add Fletcher-32 checksum (algo="fletcher")

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-07-07  Christos Longros  <chris.longros@gmail.com>
+
+	* src/digest.c: Add Fletcher-32 checksum as algorithm 14
+	* R/digest.R (digest): Register "fletcher" in algo choices
+	* R/vdigest.R (getVDigest): Idem
+	* man/digest.Rd: Document "fletcher" and add reference
+	* inst/tinytest/test_fletcher.R: Add reference check vectors
+
 2025-12-05  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/ci.yaml: Switch to actions/checkout@v6

--- a/R/digest.R
+++ b/R/digest.R
@@ -27,7 +27,7 @@
 digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
                                   "xxhash32", "xxhash64", "murmur32",
                                   "spookyhash", "blake3", "crc32c",
-                                  "xxh3_64", "xxh3_128"),
+                                  "xxh3_64", "xxh3_128", "fletcher"),
                    serialize=TRUE,
                    file=FALSE,
                    length=Inf,
@@ -43,7 +43,7 @@ digest <- function(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
     algo <- match.arg(algo, c("md5", "sha1", "crc32", "sha256", "sha512",
                               "xxhash32", "xxhash64", "murmur32",
                               "spookyhash", "blake3", "crc32c",
-                              "xxh3_64", "xxh3_128"))
+                              "xxh3_64", "xxh3_128", "fletcher"))
 
     if (is.infinite(length)) {
         length <- -1               # internally we use -1 for infinite len
@@ -155,7 +155,8 @@ algo_int <- function(algo)
         blake3 = 10,
         crc32c = 11,
         xxh3_64 = 12,
-        xxh3_128 = 13
+        xxh3_128 = 13,
+        fletcher = 14
     )
 
 ## HB 14 Mar 2007:

--- a/R/vdigest.R
+++ b/R/vdigest.R
@@ -20,16 +20,18 @@
 
 getVDigest <- function(algo = c("md5", "sha1", "crc32", "sha256", "sha512",
                                 "xxhash32", "xxhash64", "murmur32", "spookyhash",
-                                "blake3", "crc32c", "xxh3_64", "xxh3_128"),
+                                "blake3", "crc32c", "xxh3_64", "xxh3_128",
+                                "fletcher"),
                         errormode=c("stop","warn","silent")){
     algo <- match.arg(algo, c("md5", "sha1", "crc32", "sha256", "sha512",
                               "xxhash32", "xxhash64", "murmur32", "spookyhash",
-                              "blake3", "crc32c", "xxh3_64", "xxh3_128"))
+                              "blake3", "crc32c", "xxh3_64", "xxh3_128",
+                              "fletcher"))
 
     algoint <- algo_int(algo)
     non_streaming_algos <- c("md5", "sha1", "crc32", "sha256", "sha512",
                              "xxhash32", "xxhash64", "murmur32", "blake3",
-                             "crc32c", "xxh3_64", "xxh3_128")
+                             "crc32c", "xxh3_64", "xxh3_128", "fletcher")
     if (algo %in% non_streaming_algos)
         return(non_streaming_digest(algo, errormode, algoint))
     streaming_digest(algo, errormode, algoint)

--- a/inst/tinytest/test_fletcher.R
+++ b/inst/tinytest/test_fletcher.R
@@ -1,0 +1,30 @@
+
+## tests for the fletcher (Fletcher-32) algorithm
+
+suppressMessages(library(digest))
+
+## check vectors from the Fletcher's checksum reference (16-bit word blocks)
+input  <- c("abcde", "abcdef", "abcdefgh")
+output <- c("f04fc729", "56502d2a", "ebe19591")
+
+expect_identical(sapply(input, digest, algo="fletcher", serialize=FALSE,
+                        USE.NAMES=FALSE),
+                 output)
+
+## empty input reduces to zero
+expect_identical(digest("", algo="fletcher", serialize=FALSE), "00000000")
+
+## raw input matches the equivalent character input
+expect_identical(digest(charToRaw("abcde"), algo="fletcher", serialize=FALSE),
+                 digest("abcde", algo="fletcher", serialize=FALSE))
+
+## file interface agrees with the in-memory result
+tf <- tempfile()
+writeBin(charToRaw("abcdefgh"), tf)
+expect_identical(digest(tf, algo="fletcher", file=TRUE),
+                 digest("abcdefgh", algo="fletcher", serialize=FALSE))
+unlink(tf)
+
+## vectorised interface agrees with digest()
+vd <- getVDigest(algo="fletcher")
+expect_identical(vd(input, serialize=FALSE), output)

--- a/man/digest.Rd
+++ b/man/digest.Rd
@@ -156,6 +156,9 @@ digest(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
   \url{https://github.com/BLAKE3-team/BLAKE3/} for the original source code of blake3.
 
   \url{https://github.com/google/crc32c} for the (non-hardware-accelerated) crc32c code.
+
+  \url{https://en.wikipedia.org/wiki/Fletcher%27s_checksum} for a description
+  of Fletcher's checksum.
 }
 \author{Dirk Eddelbuettel \email{edd@debian.org} for the \R interface;
   Antoine Lucas for the integration of crc32; Jarek Tuszynski for the

--- a/man/digest.Rd
+++ b/man/digest.Rd
@@ -15,7 +15,7 @@
 \usage{
 digest(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
                       "xxhash32", "xxhash64", "murmur32", "spookyhash",
-                      "blake3", "crc32c", "xxh3_64", "xxh3_128"),
+                      "blake3", "crc32c", "xxh3_64", "xxh3_128", "fletcher"),
        serialize=TRUE, file=FALSE,
        length=Inf, skip="auto", ascii=FALSE, raw=FALSE, seed=0,
        errormode=c("stop","warn","silent"),
@@ -29,7 +29,7 @@ digest(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
     \code{md5}, which is also the default, \code{sha1}, \code{crc32},
     \code{sha256}, \code{sha512}, \code{xxhash32}, \code{xxhash64},
     \code{murmur32}, \code{spookyhash}, \code{blake3}, \code{crc32c},
-    \code{xxh3_64}, and \code{xxh3_128}.}
+    \code{xxh3_64}, \code{xxh3_128}, and \code{fletcher}.}
   \item{serialize}{A logical variable indicating whether the object
     should be serialized using \code{serialize} (in ASCII
     form). Setting this to \code{FALSE} allows to compare the digest
@@ -101,6 +101,10 @@ digest(object, algo=c("md5", "sha1", "crc32", "sha256", "sha512",
 
   For crc32c, the portable (i.e. non-hardware accelerated) version from
   Google is used.
+
+  For fletcher, Fletcher's 32-bit position-dependent checksum (two running
+  sums over 16-bit little-endian words, each taken modulo 65535) is computed;
+  the result is an eight-character hex string.
 
   Please note that this package is not meant to be used for
   cryptographic purposes for which more comprehensive (and widely
@@ -332,6 +336,15 @@ for (i in seq_along(crc32cInput)) {
     crc32c <- digest(crc32cInput[i], algo="crc32c", serialize=FALSE)
     cat(crc32c, "\n")
     stopifnot(identical(crc32c, crc32cOutput[i]))
+}
+
+## fletcher (Fletcher-32)
+fletcherInput  <- c("abcde", "abcdef", "abcdefgh")
+fletcherOutput <- c("f04fc729", "56502d2a", "ebe19591")
+for (i in seq_along(fletcherInput)) {
+    fletcher <- digest(fletcherInput[i], algo="fletcher", serialize=FALSE)
+    cat(fletcher, "\n")
+    stopifnot(identical(fletcher, fletcherOutput[i]))
 }
 
 # example of a digest of a standard R list structure

--- a/src/digest.c
+++ b/src/digest.c
@@ -163,6 +163,47 @@ void _store_from_int64(const uint64_t hash, char *output, const int leaveRaw) {
     } else snprintf(output, sizeof(uint64_t)*2 + 1, "%016" PRIx64, hash);
 }
 
+/*
+ * Fletcher-32 checksum: two running sums over 16-bit little-endian words,
+ * each reduced modulo 65535, concatenated as (s2 << 16) | s1. The state
+ * carries a pending low byte so a 16-bit word may span two input buffers
+ * when a file is hashed in chunks; a trailing odd byte is zero-padded.
+ */
+typedef struct {
+    uint32_t s1, s2;
+    int have_low;
+    unsigned char low;
+} fletcher32_ctx;
+
+static void fletcher32_update(fletcher32_ctx *c, const unsigned char *d,
+                              size_t n) {
+    size_t i = 0;
+    if (c->have_low && n > 0) {
+        uint32_t w = c->low | ((uint32_t) d[i++] << 8);
+        c->s1 = (c->s1 + w)     % 65535;
+        c->s2 = (c->s2 + c->s1) % 65535;
+        c->have_low = 0;
+    }
+    for (; i + 1 < n; i += 2) {
+        uint32_t w = d[i] | ((uint32_t) d[i + 1] << 8);
+        c->s1 = (c->s1 + w)     % 65535;
+        c->s2 = (c->s2 + c->s1) % 65535;
+    }
+    if (i < n) {
+        c->low = d[i];
+        c->have_low = 1;
+    }
+}
+
+static uint32_t fletcher32_final(fletcher32_ctx *c) {
+    if (c->have_low) {
+        c->s1 = (c->s1 + c->low)  % 65535;
+        c->s2 = (c->s2 + c->s1)   % 65535;
+        c->have_low = 0;
+    }
+    return (c->s2 << 16) | c->s1;
+}
+
 SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Seed) {
     size_t BUF_SIZE = 1024;
     FILE *fp=0;
@@ -331,6 +372,14 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         } else {
             snprintf(output, 128, "%016" PRIx64 "%016" PRIx64, val.high64, val.low64);
         }
+        break;
+    }
+    case 14: {     /* fletcher32 case */
+        fletcher32_ctx ctx = {0, 0, 0, 0};
+        output_length = sizeof(uint32_t);
+
+        fletcher32_update(&ctx, txt, (size_t) nChar);
+        _store_from_int32(fletcher32_final(&ctx), output, leaveRaw);
         break;
     }
     case 101: {     /* md5 file case */
@@ -654,6 +703,26 @@ SEXP digest(SEXP Txt, SEXP Algo, SEXP Length, SEXP Skip, SEXP Leave_raw, SEXP Se
         } else {
             snprintf(output, 128, "%016" PRIx64 "%016" PRIx64, val.high64, val.low64);
         }
+        break;
+    }
+    case 114: {    /* fletcher32 file case */
+        unsigned char buf[BUF_SIZE];
+        fletcher32_ctx ctx = {0, 0, 0, 0};
+        output_length = 4;
+        if (skip > 0) fseek(fp, skip, SEEK_SET);
+
+        if (length>=0) {
+            while ( ( nChar = fread( buf, 1, sizeof( buf ), fp ) ) > 0 && length>0) {
+                if (nChar>length) nChar=length;
+                fletcher32_update(&ctx, buf, (size_t) nChar);
+                length -= nChar;
+            }
+        } else {
+            while ( ( nChar = fread( buf, 1, sizeof( buf ), fp ) ) > 0)
+                fletcher32_update(&ctx, buf, (size_t) nChar);
+        }
+
+        _store_from_int32(fletcher32_final(&ctx), output, leaveRaw);
         break;
     }
 


### PR DESCRIPTION
Adds Fletcher's 32-bit checksum as `algo="fletcher"`, alongside `crc32`/`crc32c`. It computes two running sums over 16-bit little-endian words, each modulo 65535, returned as an eight-character hex string:

```r
digest("abcde", algo = "fletcher", serialize = FALSE)   # "f04fc729"
```

Registered as algorithm 14 in `algo_int()`, wired into `digest()` and `getVDigest()`, and documented in `man/digest.Rd`. 

Tests in `inst/tinytest/test_fletcher.R` cover the reference vectors plus the empty, raw, file, and `getVDigest` paths.