### PR TITLE
Add sha256 known-answer tests from the NIST FIPS 180-4 vectors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-07-11  Christos Longros  <chris.longros@gmail.com>
+
+	* DESCRIPTION (Version, Date): Roll micro version and date
+
+	* inst/tinytest/test_digest.R: Add sha256 known-answer tests using
+	the NIST test vectors for FIPS 180-4
+
 2026-07-10  Christos Longros  <chris.longros@gmail.com>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,8 +42,8 @@ Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd
              person("Kevin", "Ushey", role="ctb", comment = c(ORCID = "0000-0003-2880-7407")),
              person("Carl", "Pearson", role="ctb", comment = c(ORCID = "0000-0003-0701-7860")),
              person("Christos", "Longros", role="ctb", comment = c(ORCID = "0009-0001-2717-0857")))
-Version: 0.6.39.2
-Date: 2026-07-10
+Version: 0.6.39.3
+Date: 2026-07-11
 Title: Create Compact Hash Digests of R Objects
 Description: Implementation of a function 'digest()' for the creation of hash
  digests of arbitrary R objects (using the 'md5', 'sha-1', 'sha-256', 'crc32',

--- a/inst/tinytest/test_digest.R
+++ b/inst/tinytest/test_digest.R
@@ -80,6 +80,36 @@ for (i in seq(along.with=sha1Input)) {
     #cat(sha1, "\n")
 }
 
+## sha256 test using the NIST FIPS 180-4 test vectors
+sha256Input <-
+    c("",
+      "abc",
+      "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
+sha256Output <-
+    c("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1")
+
+for (i in seq(along.with=sha256Input)) {
+    sha256 <- digest(sha256Input[i], algo="sha256", serialize=FALSE)
+    expect_true(identical(sha256, sha256Output[i]))
+    #cat(sha256, "\n")
+}
+
+sha256 <- getVDigest(algo = 'sha256')
+expect_identical(sha256(sha256Input, serialize = FALSE), sha256Output)
+
+## sha256 raw output test
+for (i in seq(along.with=sha256Input)) {
+    sha256 <- digest(sha256Input[i], algo="sha256", serialize=FALSE, raw=TRUE)
+    sha256 <- gsub(" ","",capture.output(cat(sha256)))
+    expect_true(identical(sha256, sha256Output[i]))
+    #cat(sha256, "\n")
+}
+
+sha256 <- digest(strrep("a", 1e6), algo="sha256", serialize=FALSE)
+expect_true(identical(sha256, "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"))
+
 ## sha512 test
 sha512Input <-c(
     "",


### PR DESCRIPTION
Adds known-answer tests for sha256 based on the **NIST FIPS 180-4** vectors (empty string, "abc", the two-block message, one million 'a') via digest(), getVDigest(), and raw=TRUE.